### PR TITLE
Add basic version update script

### DIFF
--- a/update_version.sh
+++ b/update_version.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+## Usage: ./update_version.sh <version>
+
+set -e
+set -o pipefail
+
+readonly NEW_VERSION=$1
+if [ -z "$NEW_VERSION" ]; then
+  echo "You must specify the new version!"
+  exit 1
+fi
+readonly OLD_VERSION=$(grep -oP '(?<=^release \= ")\d+\.\d+\.\d+' docs/conf.py)
+
+sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/set_up_admin_tails.rst
+sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/conf.py
+
+echo "Versions updated. Verify the results with 'git diff' and be sure to tag"
+echo "a new stable version as part of the release process."


### PR DESCRIPTION
## Description

Complements removal of version update logic in https://github.com/freedomofpress/securedrop/pull/5520 . In this context, it seemed most sensible to me to decouple, as it's consistent with other repos, and the docs release is one of the final steps in the release process.