### PR TITLE
Clarify networking requirements for SecureDrop installs

### DIFF
--- a/docs/deployment/minimum_security_requirements.rst
+++ b/docs/deployment/minimum_security_requirements.rst
@@ -7,7 +7,8 @@ Minimum requirements for the SecureDrop environment
    in a location that is owned or occupied by the organization to ensure
    that their legal department can not be bypassed with gag orders.
 -  The SecureDrop servers should be on a separate internet connection or
-   completely segmented from corporate network.
+   completely segmented from the corporate network, such as a dedicated subnet 
+   with DENY rules for all traffic to and from the corporate LAN.
 -  All traffic from the corporate network should be blocked at the
    SecureDrop's point of demarcation.
 -  Video monitoring should be recorded of the server area and the


### PR DESCRIPTION
Pull requests should be opened against the `main` branch. For more information on contributing to SecureDrop documentation, see the [Documentation Guidelines](https://docs.securedrop.org/en/stable/development/documentation_guidelines.html).


## Status
*(What state is your PR in? Select one of the following and delete the option that does not apply.)*

Ready for review 


## Description of Changes

* Description: Update note for network requirements regarding corporate LAN

* Fixes [Issue#4609](https://github.com/freedomofpress/securedrop/issues/4609) (of securedrop repo)


## Testing
*(How should the reviewer test this PR? Write out any special testing steps here.)*

* n/a

## Release 
*(Any special considerations for release of this change into the stable version of the documentation?)*

* n/a 


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000



