### PR TITLE
Updated Xenial LTS version to 16.04.7, as 16.04.6 deprecated.

### DIFF
--- a/docs/development/qubes_staging.rst
+++ b/docs/development/qubes_staging.rst
@@ -57,7 +57,7 @@ In ``dom0``:
 
 .. code:: sh
 
-   qvm-start sd-staging-base --cdrom=sd-dev:/home/user/ubuntu-16.04.6-server-amd64.iso
+   qvm-start sd-staging-base --cdrom=sd-dev:/home/user/ubuntu-16.04.7-server-amd64.iso
 
 You may need to edit the filepath above if you downloaded the ISO to a
 different location within the ``sd-dev`` VM. Choose **Install Ubuntu**.

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -5,17 +5,16 @@ Set Up the Servers
 Install Ubuntu
 --------------
 
-.. caution:: Please ensure you are using Ubuntu Xenial ISO images 16.04.6 or greater.
+.. caution:: Please ensure you are using the most recent Ubuntu Xenial ISO image.
     Ubuntu Xenial ISO images 16.04.5 and lower ship with a version of the `apt` package
-    vulnerable to CVE-2019-3462. If you are using 16.04.5 or lower, the initial base OS
-    must be installed without Internet connectivity.
+    vulnerable to CVE-2019-3462.
 
 .. note:: Installing Ubuntu is simple and may even be something you are very familiar
   with, but we **strongly** encourage you to read and follow this documentation
   exactly as there are some "gotchas" that may cause your SecureDrop set up to break.
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-16.04.6 LTS (Xenial Xerus)**. To install Ubuntu on the servers, you must first
+16.04.7 LTS (Xenial Xerus)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media. You should use the *Admin
 Workstation* to download and verify the Ubuntu installation media.
 
@@ -27,7 +26,7 @@ Download the Ubuntu Installation Media
 The installation media and the files required to verify it are available on the
 `Ubuntu Releases page`_. You will need to download the following files:
 
-* `ubuntu-16.04.6-server-amd64.iso`_
+* `ubuntu-16.04.7-server-amd64.iso`_
 * `SHA256SUMS`_
 * `SHA256SUMS.gpg`_
 
@@ -43,16 +42,16 @@ Alternatively, you can use the command line:
 .. code:: sh
 
    cd ~/Persistent
-   torify curl -OOO https://releases.ubuntu.com/16.04.6/{ubuntu-16.04.6-server-amd64.iso,SHA256SUMS{,.gpg}}
+   torify curl -OOO https://releases.ubuntu.com/16.04.7/{ubuntu-16.04.7-server-amd64.iso,SHA256SUMS{,.gpg}}
 
 .. note:: Downloading Ubuntu on the *Admin Workstation* can take a while
    because Tails does everything over Tor, and Tor is typically slow relative
    to the speed of your upstream Internet connection.
 
 .. _Ubuntu Releases page: https://releases.ubuntu.com/
-.. _ubuntu-16.04.6-server-amd64.iso: https://releases.ubuntu.com/16.04.6/ubuntu-16.04.6-server-amd64.iso
-.. _SHA256SUMS: https://releases.ubuntu.com/16.04.6/SHA256SUMS
-.. _SHA256SUMS.gpg: https://releases.ubuntu.com/16.04.6/SHA256SUMS.gpg
+.. _ubuntu-16.04.7-server-amd64.iso: https://releases.ubuntu.com/16.04.7/ubuntu-16.04.7-server-amd64.iso
+.. _SHA256SUMS: https://releases.ubuntu.com/16.04.7/SHA256SUMS
+.. _SHA256SUMS.gpg: https://releases.ubuntu.com/16.04.7/SHA256SUMS.gpg
 
 Verify the Ubuntu Installation Media
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -108,13 +107,13 @@ key") means that you are not ready to proceed. ::
 
 The next and final step is to verify the Ubuntu image. ::
 
-    sha256sum -c <(grep ubuntu-16.04.6-server-amd64.iso SHA256SUMS)
+    sha256sum -c <(grep ubuntu-16.04.7-server-amd64.iso SHA256SUMS)
 
 
 If the final verification step is successful, you should see the
 following output in your terminal. ::
 
-    ubuntu-16.04.6-server-amd64.iso: OK
+    ubuntu-16.04.7-server-amd64.iso: OK
 
 .. caution:: If you do not see the line above it is not safe to proceed with the
              installation. If this happens, please contact us at
@@ -142,7 +141,7 @@ Ubuntu installer.
 If your USB is mapped to /dev/sdX and you are currently in the directory that
 contains the Ubuntu ISO, you would use dd like so: ::
 
-   sudo dd conv=fdatasync if=ubuntu-16.04.6-server-amd64.iso of=/dev/sdX
+   sudo dd conv=fdatasync if=ubuntu-16.04.7-server-amd64.iso of=/dev/sdX
 
 .. _install_ubuntu:
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

* Description: Updates references to Ubuntu LTS version to 16.04.7, as 16.04.6 is no longer available.

## Testing
- Are relevant sections of docs updated? (server setup, qubes staging env setup)

