### PR TITLE
Fix YubiKey link, ignore-list Weblate URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,6 +322,7 @@ linkcheck_ignore = [
     "https://forum.securedrop.org/admin/users/list/active",
     "https://weblate.securedrop.org/projects/securedrop/securedrop/#repository",
     "https://github.com/freedomofpress/securedrop-debian-packages-lfs",
+    r"https://weblate.securedrop.org/accounts/profile/.*",
     r"https://github.com/freedomofpress/securedrop/issues/.*",
     r"https://github.com/freedomofpress/securedrop/tree/.*",
 ]

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -19,7 +19,7 @@ Tool; for this, you require `a key that can support OATH-HOTP`_.
 
 .. _`commercially available`: https://www.yubico.com/products/yubikey-hardware/fido-u2f-security-key
 
-.. _`a key that can support OATH-HOTP`: https://support.yubico.com/support/solutions/articles/15000006467-oath-hotp-yubico-best-practices-guide
+.. _`a key that can support OATH-HOTP`: https://support.yubico.com/hc/en-us/articles/360016614780-OATH-HOTP-Yubico-Best-Practices-Guide
 
 Download and Launch the YubiKey Personalization Tool
 ----------------------------------------------------
@@ -65,8 +65,8 @@ Under **Configuration Slot**, click **Configuration Slot 1**.
 .. _`Yubikey manual`: https://www.yubico.com/wp-content/uploads/2015/03/YubiKeyManual_v3.4.pdf
 
 In the section titled **OATH-HOTP parameters**, uncheck the box for
-**OATH Token Identifier (6 bytes)**. Leave the HOTP length at 6 digits. 
-Next, uncheck the box for **Hide secret**. This will display the **Secret Key 
+**OATH Token Identifier (6 bytes)**. Leave the HOTP length at 6 digits.
+Next, uncheck the box for **Hide secret**. This will display the **Secret Key
 (20 bytes Hex)** field.
 
 .. important:: Make a note somewhere safe of the **Secret Key (20
@@ -109,4 +109,3 @@ will insert the 6-digit code that you will need to log in.
 .. |YubiKey Overview| image:: images/yubikey_overview.png
 .. |YubiKey Config| image:: images/yubikey_oath_hotp_configuration.png
 .. |YubiKey Config Successful| image:: images/yubikey_configuration_successful.png
-


### PR DESCRIPTION
Makes link check happy for a few more hours/days of its frequently unhappy existence. The Weblate URL is ignore-listed because it requires authentication.

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000



