### PR TITLE
Update SVS hardware choice instructions to avoid referring to NUC5s.

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -533,18 +533,16 @@ laptops from other manufacturers, as long as the wireless components are
 removable.
 
 Just as with the servers, you can also use an Intel NUC for the *SVS*. As noted
-before, NUCs do not ship with a hard drive, and can be configured without any
-wireless components, so you'll save time by not having to remove these, since
-they won't be present. However, NUCs *do* contain an IR receiver, which we
-recommend taping over with opaque masking tape.
+before, NUCs do not ship with a hard drive, and older models can be configured 
+without any wireless components. However, NUCs *do* contain an IR receiver, 
+which we recommend taping over with opaque masking tape.
 
-If you choose to use an Intel NUC that differs from our recommended
-model, make sure you use one that offers wireless as an **option**. If the model
-is advertised as having "integrated wireless", such as the `NUC5i5RYK`, this
-could mean it's built into the motherboard, making it physically irremovable, and
-attempting to do so would risk damaging the unit; instead, look for attributes like
-`M.2 22×30 slot and wireless antenna pre-assembled (for wireless card support)`,
-as advertised by the `NUC5i5MYHE` that we recommend.
+If you choose to use an Intel NUC, you must use an older model that offers wireless 
+as an **option** (described as something like ``M.2 22×30 slot and wireless antenna 
+pre-assembled (for wireless card support)``). If a model is advertised as having 
+"integrated wireless" (most newer NUC models), this means the wireless 
+components are not physically removable, and these machines are not a suitable 
+choice for the *SVS*.
 
 Tails USBs
 ^^^^^^^^^^


### PR DESCRIPTION

## Status
Ready for review 

## Description of Changes

* Description: Remove mention of NUC5* as "currently recommended". Updates hardware recommendations to note that most newer NUCs are not suitable for the SVS due to integrated wireless components. 

* Fixes https://github.com/freedomofpress/securedrop/issues/4869


## Testing
* manual review
* docs linting

## Release 
*(Any special considerations for release of this change into the stable version of the documentation?) * n/a


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [:x:] Doc link linting (`make docs-linkcheck`) passed (weblate link fails due to lack of authentication, can be ignored--and should probably be supressed)
- [x] You have previewed (`make docs`) docs at http://localhost:8000



