### PR TITLE
Simplify instructions for virtualizing Tails

### DIFF
--- a/docs/development/virtualizing_tails.rst
+++ b/docs/development/virtualizing_tails.rst
@@ -257,51 +257,13 @@ Linux
 For the Linux instructions, you will use KVM/libvirt to create a Tails VM that
 you can use to install SecureDrop on ``app-prod`` and ``mon-prod``.
 
-Create a libvirt VM
-~~~~~~~~~~~~~~~~~~~
+Create a VM using virt-manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Follow the Tails virt-manager instructions for
-`Running Tails from a virtual USB storage <https://tails.boum.org/doc/advanced_topics/virtualization/virt-manager/index.en.html#index5h1>`__.
-After installing Tails on the removable USB device, shut down the VM
-and edit the boot options. You'll need to manually enable booting from the USB
-device by checking the box labeled **USB Disk 1**.
+`running Tails from a USB image <https://tails.boum.org/doc/advanced_topics/virtualization/virt-manager/index.en.html#index4h1>`__.
+Then proceed with booting to the USB drive, and `configure Persistent Storage <https://tails.boum.org/doc/first_steps/persistence/index.en.html>`__.
 
-.. image:: ../images/devenv/tails-libvirt-boot-options.png
-
-Then proceed with booting to the USB drive, and configure a persistence volume.
-
-Shared Folders
-~~~~~~~~~~~~~~
-
-In order to mount the SecureDrop git repository as a folder inside the Tails
-persistence volume, you must add a filesystem via virt-manager.
-
-1. Choose **View ▸ Details** to edit the configuration of the virtual machine.
-2. Click on the **Add Hardware** button on the bottom of the left pane.
-3. Select **Filesystem** in the left pane.
-4. In the right pane, change the **Mode** to **Mapped**.
-5. In the right pane, change **Source path** to the path to the SecureDrop git repository on the host machine.
-6. In the right pane, change **Target path** to **securedrop**.
-7. Click **Finish**.
-
-.. image:: ../images/devenv/tails-libvirt-filesystem-config.png
-
-On the next VM boot, you will be able to mount the SecureDrop git repository
-from the host machine via:
-
-.. code:: sh
-
-  mkdir -p ~/Persistent/securedrop
-  sudo mount -t 9p securedrop ~/Persistent/securedrop
-
-You will need to run the ``mount`` command every time you boot the VM.
-By default only read operations are supported. In order to support modifying files
-in the git repository, you will need to configure file ACLs.
-On the host machine, from within the SecureDrop git repository, run:
-
-.. code:: sh
-
-  make libvirt-share
-
-All files will be created with mode ``0600`` and ownership ``libvirt-qemu:libvirt-qemu``.
-You will need to modify the files manually on the host machine in order to commit them.
+We recommend cloning the SecureDrop repository into the persistent volume for
+testing and development, instead of attempting to mount a folder from the host
+operating system.

--- a/docs/images/devenv/tails-libvirt-boot-options.png
+++ b/docs/images/devenv/tails-libvirt-boot-options.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db9ca30e6a177848e054ed75501dba66ded560e78c7ebfe1a979da04ca22a627
-size 55007

--- a/docs/images/devenv/tails-libvirt-filesystem-config.png
+++ b/docs/images/devenv/tails-libvirt-filesystem-config.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1816f976d1af6d56f4097235c18dae4c4f0e1972d1d6327705c92f02751e407
-size 61175


### PR DESCRIPTION
## Status
Ready for review 

## Description of Changes

- Just refer to Tails docs, which are sufficient and complete
- Don't attempt to set up shared folders, which is fickle and not used in practice.

Fixes #18
Fixes https://github.com/freedomofpress/securedrop/issues/4513

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000