### PR TITLE
Replace Onion v2 generators, v3 today

### DIFF
--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -44,8 +44,7 @@ recipients and anyone else interested
 -  Explain why the *Journalist Interface* does not have 'is it up?'
    monitoring
 -  Discuss vanity onion URLs with
-   `Shallot <https://github.com/katmagic/Shallot>`__ and
-   `Scallion <https://github.com/lachesis/scallion>`__
+   `mkp224o <https://github.com/cathugger/mkp224o>`__ 
 -  How to brand the *Source Interface* and *Journalist Interface*
 -  Physical security of servers and *SVS*
 -  How to securely publicize the organization's Source Interface Tor URL


### PR DESCRIPTION
To my knowledge scallion and shallot aren't maintained/upgraded to the v3 style onions. This one does and isn't as inefficient as I expected (up to 6 characters).

## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review / Work in progress


## Description of Changes

* Description: 

* Fixes Issue#


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
*

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* 


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000