### PR TITLE
Replace reference to vanity addresses w/ onion names

### DIFF
--- a/docs/training_schedule.rst
+++ b/docs/training_schedule.rst
@@ -43,9 +43,7 @@ recipients and anyone else interested
    Interface
 -  Explain why the *Journalist Interface* does not have 'is it up?'
    monitoring
--  Discuss vanity onion URLs with
-   `Shallot <https://github.com/katmagic/Shallot>`__ and
-   `Scallion <https://github.com/lachesis/scallion>`__
+-  Overview of `onion names <https://securedrop.org/news/introducing-onion-names-securedrop/>`__
 -  How to brand the *Source Interface* and *Journalist Interface*
 -  Physical security of servers and *SVS*
 -  How to securely publicize the organization's Source Interface Tor URL


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

We do not recommend vanity addresses, and they're rendered somewhat obsolete by the onion name feature. Since this is a change to the training schedule, already flagged to @harlo

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000