### PR TITLE
Added hardware recommendation and setup instructions for NUC8i5BEK

### DIFF
--- a/docs/images/hardware/nuc8_leads.jpg
+++ b/docs/images/hardware/nuc8_leads.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4224f662f374f2b7504041cdaeb9f9f11e7644fbe789387ac7f23c671723a825
+size 572062

--- a/docs/images/hardware/nuc8_visualbios1.png
+++ b/docs/images/hardware/nuc8_visualbios1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb247f86d551a112b4a7c97853d5356311447bb5f198265b185f80d9b2c22480
+size 30637

--- a/docs/images/hardware/nuc8_visualbios2.png
+++ b/docs/images/hardware/nuc8_visualbios2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa03405aebe8245b6a9d5a89fd2871c6cfd24aa53308c902de5b6644182c323f
+size 33233

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -151,6 +151,10 @@ Perform the Installation
 The steps below are the same for both the *Application Server* and the
 *Monitor Server*.
 
+.. note:: If you're installing Ubuntu 16.04 on a NUC8, you will need a 16.04-compatible
+  USB Ethernet adaptor attached to complete the steps below. See the
+  :ref:`nuc8_recommendation` notes in the recommended hardware list for more information.
+
 Start by inserting the Ubuntu installation media into the server. Boot
 or reboot the server with the installation media inserted, and enter the
 boot menu. To enter the boot menu, you need to press a key as soon as
@@ -298,10 +302,16 @@ When the packages are finished installing, Ubuntu will automatically
 install the bootloader (GRUB). If it asks to install the bootloader to
 the Master Boot Record, choose **Yes**. When everything is done, reboot.
 
+.. note:: If you're installing Ubuntu on a NUC8 using a USB Ethernet adaptor,
+  you should now complete the steps listed in :ref:`nuc8_enable_network` before
+  proceeding with the rest of the installaton.
+
 .. |Ubuntu Server| image:: images/install/ubuntu_server.png
 
+.. _nuc8_back_to_setup:
+
 Save the Configurations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 When you are done, make sure you save the following information:
 


### PR DESCRIPTION
## Status

Ready for review

* Description: 

* Addresses issue: https://github.com/freedomofpress/securedrop/issues/5304

Adds hardware recommendation for NUC8i5BEK. 

As this NUC's NIC is not supported by 16.04 OOB, the PR also includes instructions on enabling support via the Ubuntu HWE kernel as a prerequisite for the SecureDrop install.

## Testing

* Review for clarity and correctness.
* If a USB Ethernet adaptor and NUC8 is available, run through the new process added.

## Release 
* No release issues, can go anytime.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed - **didn't check**
- [x] You have previewed (`make docs`) docs at http://localhost:8000