### PR TITLE
Update average throughput onion

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -25,7 +25,7 @@ encourage Journalists to delete regularly unneeded submissions from the *Journal
 Interface*.
 
 .. tip:: Although it varies, the average throughput of an onion service is
-         about 150 kB/s, or roughly 4 hours for 2GB. Plan your backup and
+         about 300 kB/s, or roughly 2 hours for 2GB. Plan your backup and
          restore accordingly.
 
 You can use the following command to determine the volume of submissions


### PR DESCRIPTION
Checked the data available in metrics.torproject.org which confirmed my suspicion: it's faster as it once was. My eyeball guess is that a the average throughput to onions is rather 2.5Mbps, conservative. 300 kB/s is even less, but double the speed as what was written here.

## Status

Ready for review 


## Description of Changes

* Description: update on Tip for admins regarding average throughput of onions.


## Testing

* see metrics.torproject.org
