### PR TITLE
Replace instances for OSSEC Alert Key

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -49,13 +49,12 @@ Instructions for using SecureDrop as a *Journalist* are available in our
 :doc:`Journalist Guide <journalist>`.
 
 
-Journalist Alert Key
---------------------
-The *Journalist Alert Key* is used for encrypting the alert that notifies journalists daily 
-via encrypted email about whether or not there has been submission activity 
-in the past 24 hours. More information about journalist alerts, is in our 
-:doc:`Journalist Guide <journalist>`.
-
+Journalist Alert Public Key
+---------------------------
+The *Journalist Alert Public Key* is used for encrypting the :ref:`daily alert <daily_journalist_alerts>`
+that notifies journalists via encrypted email about whether or not there has been
+submission activity in the past 24 hours. The journalist uses an associated
+private key to decrypt the alerts.
 
 Journalist Interface
 --------------------
@@ -98,8 +97,9 @@ to this server, and they may only do so using Tor.
 OSSEC Alert Public Key
 ----------------------
 The *OSSEC Alert Public Key* is the GPG key that OSSEC will encrypt alerts to.
-It is used by the admin to access encrypted OSSEC alerts from the Monitor Server.
-Instructions about setting up OSSEC alerts are available in the :doc:`OSSEC Guide <ossec_alerts>`.
+The associated private key is used by the admin to access encrypted OSSEC alerts
+from the *Monitor Server*. Instructions for setting up OSSEC alerts can be found
+in the :doc:`OSSEC Guide <ossec_alerts>`.
 
 
 .. _svs:
@@ -133,7 +133,7 @@ SecureDrop to communicate with a *Journalist*. A *Source* will always
 access SecureDrop through the *Source Interface* and must do so using Tor.
 
 Instructions for using SecureDrop as a *Source* are available in our
-:doc: `Source Guide <source>`.
+:doc:`Source Guide <source>`.
 
 
 Source Interface

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -6,19 +6,36 @@ diagram <https://docs.securedrop.org/en/latest/overview.html#infrastructure>`__,
 are specific to SecureDrop. The list below attempts to enumerate and
 define these terms.
 
-Source
-------
 
-The *Source* is the person who submits documents to SecureDrop and may use
-SecureDrop to communicate with a *Journalist*. A *Source* will always
-access SecureDrop through the *Source Interface* and must do so using Tor.
+Admin Workstation
+-----------------
+The *Admin Workstation* is a machine that the system admin can
+use to connect to the *Application Server* and the *Monitor Server* using Tor
+and SSH. The admin will also need to have an Android or iOS
+device with the FreeOTP app installed.
 
-Instructions for using SecureDrop as a *Source* are available in our
-`Source Guide <https://docs.securedrop.org/en/latest/source.html>`__.
+
+Application Server
+------------------
+The *Application Server* runs the SecureDrop application. This server hosts both
+the website that sources access (the *Source Interface*) and the website that
+journalists access (the *Journalist Interface*). Sources, journalists, and
+admins may only connect to this server using Tor.
+
+
+Export Device
+-------------
+The *Export Device* is the physical media (e.g., designated USB drive) used to
+transfer decrypted documents from the *Secure Viewing Station* to a journalist's
+everyday workstation, or to another computer for additional processing.
+
+Please see the detailed security recommendations for the choice, configuration
+and use of your *Export Device* in the :doc:`journalist guide <journalist>`
+and in the :doc:`setup guide <set_up_transfer_and_export_device>` .
+
 
 Journalist
 ----------
-
 The *Journalist* uses SecureDrop to communicate with and download documents
 submitted by the *Source*. Journalists do this by using the *Journalist
 Workstation* to connect to the *Journalist Interface* through Tor.
@@ -31,41 +48,17 @@ being transferred to an Internet-connected computer.
 Instructions for using SecureDrop as a *Journalist* are available in our
 `Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
 
-Application Server
-------------------
 
-The *Application Server* runs the SecureDrop application. This server hosts both
-the website that sources access (the *Source Interface*) and the website that
-journalists access (the *Journalist Interface*). Sources, journalists, and
-admins may only connect to this server using Tor.
+Journalist Alert Key
+--------------------
+The *Journalist Alert Key* is an alert that notifies journalists daily 
+via encrypted email about whether or not there has been submission activity 
+in the past 24 hours. More information about journalist alerts, is in our 
+`Journalist Guide <https://docs.securedrop.org/en/stable/journalist.html#daily-journalist-alerts-about-submissions>`__.
 
-Monitor Server
---------------
-
-The *Monitor Server* keeps track of the *Application Server* and sends out an
-email alert if something seems wrong. Only system admins connect
-to this server, and they may only do so using Tor.
-
-Landing Page
-------------
-
-The *Landing Page* is the public-facing webpage for a SecureDrop instance. This
-page is hosted as a standard (i.e. non-Tor) webpage on the news organization's
-site. It provides first instructions for potential sources.
-
-Source Interface
-----------------
-
-The *Source Interface* is the website that sources will access to
-submit documents and communicate with journalists. This site is
-hosted on the *Application Server* and can only be accessed through Tor.
-
-Instructions for using the *Source Interface* are available in our `Source Guide
-<https://docs.securedrop.org/en/latest/source.html>`__.
 
 Journalist Interface
 --------------------
-
 The *Journalist Interface* is the website that journalists access to download
 new documents and communicate with sources. This site is hosted on the
 *Application Server* and can only be accessed over Tor. In previous releases,
@@ -75,9 +68,9 @@ ambiguity.
 Instructions for using the *Journalist Interface* are available in our
 `Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
 
+
 Journalist Workstation
 ----------------------
-
 The *Journalist Workstation* is a machine that is online and used
 together with the Tails operating system on the *online* USB stick. This
 machine will be used to connect to the *Journalist Interface*, download
@@ -87,19 +80,39 @@ documents, and move them to the *Secure Viewing Station* using the
 Instructions for using the *Journalist Workstation* are available in our
 `Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
 
-Admin Workstation
------------------
 
-The *Admin Workstation* is a machine that the system admin can
-use to connect to the *Application Server* and the *Monitor Server* using Tor
-and SSH. The admin will also need to have an Android or iOS
-device with the FreeOTP app installed.
+Landing Page
+------------
+The *Landing Page* is the public-facing webpage for a SecureDrop instance. This
+page is hosted as a standard (i.e. non-Tor) webpage on the news organization's
+site. It provides first instructions for potential sources.
+
+
+Monitor Server
+--------------
+The *Monitor Server* keeps track of the *Application Server* and sends out an
+email alert if something seems wrong. Only system admins connect
+to this server, and they may only do so using Tor.
+
+
+OSSEC Alert Public Key
+----------------------
+The *OSSEC Alert Public Key* is the GPG key that OSSEC will encrypt alerts to.
+It is used by the admin to access encrypted OSSEC alerts from the Monitor Server.
+
+Copy the *OSSEC Alert Public Key* to ``install_files/ansible-base`` and then 
+specify the filename, (e.g. ``ossec.pub``, in the ``ossec_alert_gpg_public_key`` 
+line of ``group_vars/all/site-specific``.
+
+If you don’t have your *OSSEC Alert Public Key* ready, you can run ``GnuPG`` on 
+the command line to find, import, and export your public key. Instructions about 
+setting up OSSEC alerts are available in the `OSSEC Guide <https://docs.securedrop.org/en/stable/ossec_alerts.html>`_.
+
 
 .. _svs:
 
 Secure Viewing Station
 ----------------------
-
 The *Secure Viewing Station* (or *SVS* for short) is the computer you use to
 decrypt and view documents and messages submitted to your SecureDrop. This
 computer is permanently kept offline. It is "air-gapped", meaning that there
@@ -119,11 +132,31 @@ system other than Tails on a USB, it does not need a hard drive or
 network device. We recommend physically removing the drive and any
 networking cards (wireless, Bluetooth, etc.) from this machine.
 
+
+Source
+------
+The *Source* is the person who submits documents to SecureDrop and may use
+SecureDrop to communicate with a *Journalist*. A *Source* will always
+access SecureDrop through the *Source Interface* and must do so using Tor.
+
+Instructions for using SecureDrop as a *Source* are available in our
+`Source Guide <https://docs.securedrop.org/en/latest/source.html>`__.
+
+
+Source Interface
+----------------
+The *Source Interface* is the website that sources will access to
+submit documents and communicate with journalists. This site is
+hosted on the *Application Server* and can only be accessed through Tor.
+
+Instructions for using the *Source Interface* are available in our `Source Guide
+<https://docs.securedrop.org/en/latest/source.html>`__.
+
+
 .. _submission-key:
 
 Submission Key
 --------------
-
 The *Submission Key* is the GPG keypair used to encrypt and decrypt documents
 and messages sent to your SecureDrop. Because the public key and private key
 must be treated very differently, we sometimes refer to them explicitly as the
@@ -137,19 +170,6 @@ The *Submission Private Key* should never be accessible to a computer with
 Internet connectivity. Instead, it should remain on the *Secure Viewing Station*
 and on offline backup storage.
 
-Two-Factor Authentication
--------------------------
-
-There are several places in the SecureDrop architecture where two-factor
-authentication is used to protect access to sensitive information or
-systems. These instances use the standard TOTP and/or HOTP algorithms,
-and so a variety of devices can be used to generate 6-digit two-factor
-authentication codes. We recommend using one of:
-
--  FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ or `for iOS <https://itunes.apple.com/us/app/freeotp-authenticator/id872559395>`__ installed
--  A `YubiKey <https://www.yubico.com/products/yubikey-hardware/>`__
-
-.. include:: includes/otp-app.txt
 
 Transfer Device
 ---------------
@@ -161,12 +181,16 @@ Please see the detailed security recommendations for the choice, configuration
 and use of your *Transfer Device* in the :doc:`journalist guide <journalist>`
 and in the :doc:`setup guide <set_up_transfer_and_export_device>`.
 
-Export Device
--------------
-The *Export Device* is the physical media (e.g., designated USB drive) used to
-transfer decrypted documents from the *Secure Viewing Station* to a journalist's
-everyday workstation, or to another computer for additional processing.
 
-Please see the detailed security recommendations for the choice, configuration
-and use of your *Export Device* in the :doc:`journalist guide <journalist>`
-and in the :doc:`setup guide <set_up_transfer_and_export_device>` .
+Two-Factor Authentication
+-------------------------
+There are several places in the SecureDrop architecture where two-factor
+authentication is used to protect access to sensitive information or
+systems. These instances use the standard TOTP and/or HOTP algorithms,
+and so a variety of devices can be used to generate 6-digit two-factor
+authentication codes. We recommend using one of:
+
+-  FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ or `for iOS <https://itunes.apple.com/us/app/freeotp-authenticator/id872559395>`__ installed
+-  A `YubiKey <https://www.yubico.com/products/yubikey-hardware/>`__
+
+.. include:: includes/otp-app.txt

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -31,7 +31,7 @@ everyday workstation, or to another computer for additional processing.
 
 Please see the detailed security recommendations for the choice, configuration
 and use of your *Export Device* in the :doc:`journalist guide <journalist>`
-and in the :doc:`setup guide <set_up_transfer_and_export_device>` .
+and in the :doc:`setup guide <set_up_transfer_and_export_device>`.
 
 
 Journalist
@@ -46,15 +46,15 @@ they can be prepared for publication on the *Secure Viewing Station* before
 being transferred to an Internet-connected computer.
 
 Instructions for using SecureDrop as a *Journalist* are available in our
-`Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
+:doc:`Journalist Guide <journalist>`.
 
 
 Journalist Alert Key
 --------------------
-The *Journalist Alert Key* is an alert that notifies journalists daily 
+The *Journalist Alert Key* is used for encrypting the alert that notifies journalists daily 
 via encrypted email about whether or not there has been submission activity 
 in the past 24 hours. More information about journalist alerts, is in our 
-`Journalist Guide <https://docs.securedrop.org/en/stable/journalist.html#daily-journalist-alerts-about-submissions>`__.
+:doc:`Journalist Guide <journalist>`.
 
 
 Journalist Interface
@@ -66,7 +66,7 @@ this was called the *Document Interface*, but we have renamed it to avoid
 ambiguity.
 
 Instructions for using the *Journalist Interface* are available in our
-`Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
+:doc:`Journalist Guide <journalist>`.
 
 
 Journalist Workstation
@@ -78,7 +78,7 @@ documents, and move them to the *Secure Viewing Station* using the
 *Transfer Device*.
 
 Instructions for using the *Journalist Workstation* are available in our
-`Journalist Guide <https://docs.securedrop.org/en/latest/journalist.html>`__.
+:doc:`Journalist Guide <journalist>`.
 
 
 Landing Page
@@ -99,14 +99,7 @@ OSSEC Alert Public Key
 ----------------------
 The *OSSEC Alert Public Key* is the GPG key that OSSEC will encrypt alerts to.
 It is used by the admin to access encrypted OSSEC alerts from the Monitor Server.
-
-Copy the *OSSEC Alert Public Key* to ``install_files/ansible-base`` and then 
-specify the filename, (e.g. ``ossec.pub``, in the ``ossec_alert_gpg_public_key`` 
-line of ``group_vars/all/site-specific``.
-
-If you don’t have your *OSSEC Alert Public Key* ready, you can run ``GnuPG`` on 
-the command line to find, import, and export your public key. Instructions about 
-setting up OSSEC alerts are available in the `OSSEC Guide <https://docs.securedrop.org/en/stable/ossec_alerts.html>`_.
+Instructions about setting up OSSEC alerts are available in the :doc:`OSSEC Guide <ossec_alerts>`.
 
 
 .. _svs:
@@ -140,7 +133,7 @@ SecureDrop to communicate with a *Journalist*. A *Source* will always
 access SecureDrop through the *Source Interface* and must do so using Tor.
 
 Instructions for using SecureDrop as a *Source* are available in our
-`Source Guide <https://docs.securedrop.org/en/latest/source.html>`__.
+:doc: `Source Guide <source>`.
 
 
 Source Interface
@@ -149,8 +142,8 @@ The *Source Interface* is the website that sources will access to
 submit documents and communicate with journalists. This site is
 hosted on the *Application Server* and can only be accessed through Tor.
 
-Instructions for using the *Source Interface* are available in our `Source Guide
-<https://docs.securedrop.org/en/latest/source.html>`__.
+Instructions for using the *Source Interface* are available in our :doc:`Source Guide
+<source>`.
 
 
 .. _submission-key:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -88,8 +88,8 @@ submission activity for journalists. These help journalists avoid spending time
 checking the *Journalist Interface* when there are no submissions. For this you
 will need:
 
--  the journalist alerts GPG key
--  the journalist alerts GPG key fingerprint
+-  the *Journalist Alert Public Key* 
+-  the *Journalist Alert Public Key*  fingerprint
 -  the email address that will receive the journalist alerts
 
 .. note:: It is not possible to specify multiple email addresses for email
@@ -104,7 +104,7 @@ Before proceeding, you will need to copy the following files to
 ``install_files/ansible-base``:
 
 -  the *Submission Public Key* file
--  the admin's GPG public key file (for encrypting OSSEC alerts)
+-  the *OSSEC Alert Public Key*
 
 The *Submission Public Key* should be located on your *Transfer
 Device* from earlier. Its exact path will depend on the location where the USB stick

--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -24,7 +24,7 @@ prior to installing SecureDrop.
 
 What you need:
 
--  The GPG key that OSSEC will encrypt alerts to
+-  The *OSSEC Alert Public Key*
 -  The email address that will receive alerts from OSSEC
 -  Information for your SMTP server or relay (hostname, port)
 -  Credentials for the email address that OSSEC will send alerts from
@@ -54,7 +54,7 @@ For first-time installs, you can use the
 :ref:`configuration playbook<configure_securedrop>`, or edit
 ``install_files/ansible-base/group_vars/all/site-specific`` manually.
 
-- GPG public key used to encrypt OSSEC alerts:
+- *OSSEC Alert Public Key*:
   ``ossec_alert_gpg_public_key``
 - Fingerprint of key used when encrypting OSSEC alerts:
   ``ossec_gpg_fpr``
@@ -88,7 +88,7 @@ documentation <http://www.postfix.org/documentation.html>`__ for help,
 although we've described some common scenarios in the
 :ref:`troubleshooting section <troubleshooting_ossec>`.
 
-If you have your GPG public key handy, copy it to
+If you have your *OSSEC Alert Public Key* public key handy, copy it to
 ``install_files/ansible-base`` and then specify the filename, e.g.
 ``ossec.pub``, in the ``ossec_alert_gpg_public_key`` line of
 ``group_vars/all/site-specific``.
@@ -334,7 +334,7 @@ then run the playbook again.
 
 Message Failed to Encrypt
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-If OSSEC cannot encrypt the alert to the GPG public key for the Admin
+If OSSEC cannot encrypt the alert to the *OSSEC Alert Public Key* for the Admin
 email address (configured as ``ossec_alert_email`` in ``group_vars/all/site-specific``),
 the system will send a static message instead of the scheduled alert:
 

--- a/docs/passphrases.rst
+++ b/docs/passphrases.rst
@@ -33,7 +33,7 @@ passphrases:
       (required to be the same for both servers).
    -  The network firewall username and password.
    -  The SSH private key and, if set, the key's passphrase.
-   -  The GPG key that OSSEC will encrypt alerts to.
+   -  The *OSSEC Alert Public Key*.
    -  The admin's personal GPG public key, if you want to potentially encrypt
       sensitive files to it for further analysis.
    -  The account details for the destination email address for OSSEC alerts.

--- a/docs/rebuild_admin.rst
+++ b/docs/rebuild_admin.rst
@@ -296,7 +296,7 @@ using the command:
 
  curl http://$(cat app-source-ths)/metadata
 
-To copy the OSSEC alert public key, first list available keys on the monitor server:
+To copy the *OSSEC Alert Public Key*, first list available keys on the monitor server:
 
 .. code:: sh
 

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -231,7 +231,7 @@ the template are:
 - Email account for sending OSSEC alerts
 - Monitor Server SSH Onion URL
 - Network Firewall Admin Credentials
-- OSSEC Alert Public Key
+- *OSSEC Alert Public Key*
 - SecureDrop Login Credentials
 
 **Journalist**:

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -231,7 +231,7 @@ the template are:
 - Email account for sending OSSEC alerts
 - Monitor Server SSH Onion URL
 - Network Firewall Admin Credentials
-- OSSEC GPG Key
+- OSSEC Alert Public Key
 - SecureDrop Login Credentials
 
 **Journalist**:

--- a/docs/threat_model/mitigations.rst
+++ b/docs/threat_model/mitigations.rst
@@ -182,15 +182,17 @@ Attacks on Network Infrastructure
 -  Landing Page is framed or unavailable
 -  Landing Page DNS leaks from SecureDrop/leaks-related subdomain
 -  Communications vulnerability in *Source* or *Journalist Interface*
--  DNS requests to news organization's subdomain for SecureDrop Landing Page, Freedom.press, torproject.org Tor activity, SD submissions may be correlated
+-  DNS requests to news organization's subdomain for SecureDrop Landing Page, 
+   Freedom.press, torproject.org Tor activity, SD submissions may be correlated
 -  SecureDrop.org is compromised
 -  User web traffic to SecureDrop Landing Page uses CDN and may be logged
 -  Tor network exploit
 -  apt server man-in-the-middle used to serve old or malicious packages
 -  SecureDrop apt servers are compromised, or apt server man-in-the middle attack injects malicious packages
 -  News Organization network is compromised
--  OSSEC and/or Journalist alert SMTP account credentials compromised
--  OSSEC and/or Journalist alert private key compromised
+-  *OSSEC Alert Public Key* and/or *Journalist Alert Public Key* SMTP account 
+   credentials are compromised
+-  *OSSEC Alert Public Key* and/or *Journalist Alert Private Key* are compromised
 -  SMTP relay compromised
 -  Admin's network is monitored
 

--- a/docs/threat_model/mitigations.rst
+++ b/docs/threat_model/mitigations.rst
@@ -190,9 +190,8 @@ Attacks on Network Infrastructure
 -  apt server man-in-the-middle used to serve old or malicious packages
 -  SecureDrop apt servers are compromised, or apt server man-in-the middle attack injects malicious packages
 -  News Organization network is compromised
--  *OSSEC Alert Public Key* and/or *Journalist Alert Public Key* SMTP account 
-   credentials are compromised
--  *OSSEC Alert Public Key* and/or *Journalist Alert Private Key* are compromised
+-  OSSEC and/or Journalist alert SMTP account credentials compromised
+-  OSSEC and/or Journalist alert private key compromised
 -  SMTP relay compromised
 -  Admin's network is monitored
 

--- a/docs/threat_model/threat_model.rst
+++ b/docs/threat_model/threat_model.rst
@@ -270,8 +270,8 @@ What a Comprommise of the *Monitor Server* Can Surrender
 
 -  The server stores the plaintext alerts on disk, data may also reside
    in RAM.
--  The server stores the GPG public key the OSSEC alerts are encrypted
-   to.
+-  The server stores the *OSSEC Alert Public Key* the OSSEC alerts are 
+   encrypted to.
 -  The server stores plaintext credentials for the SMTP relay used to
    send OSSEC alerts.
 -  The server stores the email address the encrypted OSSEC alerts are


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for Review

## Description of Changes

* **Description**: Define and standardize OSSEC Alert Key terminology. Replace "the admin’s GPG public key file (for encrypting OSSEC alerts)" and similar description with OSSEC Alert Key or OSSEC Alert Public Key, and call the key for the 24h alerts the Journalist Alert Key or Journalist Alert Public Key.

* Fixes #44


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
*

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* 


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000