### PR TITLE
update SecureDrop onion address to v3 url

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -140,7 +140,8 @@ behavior, regardless of the use of HTTPS.
 
 We suggest offering a reference to the SecureDrop Onion Service in
 plain text, without a hyperlink (as per the preceding section):
-**secrdrop5wyphb5x.onion**
+
+**sdolvtfhatvsysc6l34d65ymdwxcujausv7k5jk4cy5ttzhjoi6fzvyd.onion**
 
 Apply Security Headers
 ----------------------

--- a/docs/source.rst
+++ b/docs/source.rst
@@ -122,7 +122,7 @@ the organization that you wish to submit to.
    through the SecureDrop Website, using Tor Browser. For additional
    security, you can use our .onion service address in Tor:
 
-   ``secrdrop5wyphb5x.onion/report-an-error``
+   ``sdolvtfhatvsysc6l34d65ymdwxcujausv7k5jk4cy5ttzhjoi6fzvyd.onion/report-an-error``
 
    We will update the directory entry if the information in it is incorrect.
 


### PR DESCRIPTION
## Status
Ready for review 

## Description of Changes
Replace references to SecureDrop v2 onion services url with v3  

## Testing
visual review

## Release 
n/a

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed 
- [x] You have previewed (`make docs`) docs at http://localhost:8000