### PR TITLE
Update reference to Source Interface /journalist-key route

### DIFF
--- a/docs/rebuild_admin.rst
+++ b/docs/rebuild_admin.rst
@@ -279,7 +279,7 @@ it locally using the following commands:
 .. code:: sh
 
  cd ~/Persistent/securedrop/install_files/ansible-base
- curl http://$(cat app-source-ths)/journalist-key > SecureDrop.asc
+ curl http://$(cat app-source-ths)/public-key > SecureDrop.asc
  gpg --import SecureDrop.asc
 
 Validate that the imported key's fingerprint matches the one on your


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review.

## Description of Changes

* Description: 

Update instructions to get GPG key to use the new `/public-key` route instead of `/journalist-key` which will be deprecated.

* Fixes #111 

## Testing

- [ ] Verify the instructions in the Retrieve GPG Public Keys section of **Rebuilding an Admin Workstation USB** refer to `/public-key` instead of `/journalist-key`, specifically in the `curl` command of the following block:

    ```
    cd ~/Persistent/securedrop/install_files/ansible-base
    curl http://$(cat app-source-ths)/public-key > SecureDrop.asc
    gpg --import SecureDrop.asc
    ```

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* Synchronize with the release of the changes in https://github.com/freedomofpress/securedrop/pull/5651.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000