### PR TITLE
Fix broken link to page of historical relevance

### DIFF
--- a/docs/getting_the_most_out_of_securedrop.rst
+++ b/docs/getting_the_most_out_of_securedrop.rst
@@ -91,7 +91,7 @@ proof of concept Twitter advertisement aimed at EPA and NOAA employees to show
 how it can be done. You can read about `how you can do the same thing here`_.
 
 .. _`recently targeted online advertisements`: https://www.wsj.com/articles/gizmodo-ads-target-potential-trump-leakers-1487191482
-.. _`tell on trump`: https://specialprojectsdesk.com/tell-on-trump-1792401813
+.. _`tell on trump`: https://web.archive.org/web/20201114212453/https://specialprojectsdesk.com/tell-on-trump-1792401813
 .. _`how you can do the same thing here`: https://freedom.press/news/we-targeted-securedrop-ad-potential-whistleblowers-trump-administration-you-can-too/
 
 Put an Advertisement in Your Physical Paper


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Description:  `make linkcheck` was failing due to a `HTTP 410 Gone` response. I can confirm that the page is gone, but it is available in the [Wayback Machine of the Internet Archive](https://archive.org/web). Since the page was cited as a reference of past ad campaigns, I think the archived page fits the purpose.

* Doesn't fix, but is related to issue https://github.com/freedomofpress/securedrop-docs/issues/5


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] Check that the newly-linked archived page matches the original

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
I don't think this change requires any special considerations.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed :warning: **No** but the error is not related to this link anymore, see [comment](https://github.com/freedomofpress/securedrop-docs/pull/118#issuecomment-753459082).
- [x] You have previewed (`make docs`) docs at http://localhost:8000