### PR TITLE
Enable nightly linkcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,31 @@ jobs:
           name: Run lint
           command: make docs-lint
 
+  linkcheck:
+    docker:
+      - image: python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip install --require-hashes -r requirements/requirements.txt
+      - run:
+          name: Run link check
+          command: make docs-linkcheck
+
 workflows:
   version: 2
   build:
     jobs:
       - lint
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 3 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - linkcheck

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -208,7 +208,7 @@ Connect to the pfSense WebGUI
 
    |Default pfSense|
 
-.. _intentionally disables LAN access: https://labs.riseup.net/code/issues/7976
+.. _intentionally disables LAN access: https://gitlab.tails.boum.org/tails/tails/-/issues/7976
 
 Alternate Hostnames
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Status

Ready for review (unless there is something to do in the [SecureDrop Core repository](https://github.com/freedomofpress/securedrop/blob/1.6.0/.circleci/config.yml#L295-L309))


## Description of Changes

* Description: Adds a `linkcheck` job, and a nighly trigger on the `main` branch at 03:00 AM (the SecureDrop Core nightly jobs [run at 04:00 AM](https://github.com/freedomofpress/securedrop/blob/1.6.0/.circleci/config.yml#L386-L395)).

* Fixes #5 


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] Review the job's command
- [ ] Review the trigger schedule
- [ ] Review the trigger branch filter
- [ ] Confirm if there is anything that should be done in the SD Core repo

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* Make sure that `make docs-linkcheck` passes locally to avoid breaking the build on the first night
* Take a look at the build the day after release to make sure the nightly ran as expected.


## Checklist (Optional)

- [ ] ~Doc linting (`make docs-lint`) passed locally~
- [ ] ~Doc link linting (`make docs-linkcheck`) passed~
- [ ] ~You have previewed (`make docs`) docs at http://localhost:8000~