### PR TITLE
Add clarification on translation of HTML content

### DIFF
--- a/docs/development/l10n.rst
+++ b/docs/development/l10n.rst
@@ -159,15 +159,22 @@ HTML content
 ^^^^^^^^^^^^
 
 Some source strings represent HTML that will be presented in the
-SecureDrop web interface. It can be hard to tell what to translate,
-since HTML is source code and changing the wrong thing can break the
-page layout.
+SecureDrop web interface.
 
-One thing you should always translate are ``alt`` attributes of image
-elements. Image elements (``<img>``) in HTML place a picture on the
-page. People with visual impairments rely on a special note on the
-image element -- the ``alt`` attribute -- to describe the image, so
-it's helpful to translate those. Here's an example that contains an
+HTML elements (embraced by in ``<``, ``>``, example: ``<strong>``)
+can contain multiple so-called *attributes*.
+
+The text of the two attributes called ``alt`` and ``title``
+should be translated. The text of the other attributes should not
+be translated.
+
+Attribute ``alt``
+"""""""""""""""""
+
+Image elements (``<img>``) in HTML place a picture on the
+page. Because people with visual impairments rely on a special note
+on the image element -- the ``alt`` attribute -- to describe the image,
+it is necessary to translate those. Here's an example that contains an
 image with both an ``alt`` attribute *and* a placeholder::
 
   <img src="{icon}" alt="shield icon">
@@ -178,6 +185,36 @@ attribute of the ``<img>`` element should not be translated. The
 translated HTML in Portuguese would be::
 
   <img src="{icon}" alt="ícone do escudo">
+
+Attribute ``title``
+"""""""""""""""""""
+
+Links (``<a>``) and abbreviations (``<abbr>``) sometimes rely on
+an additional ``title`` attribute. The content of that attribute is
+usually shown when placing a cursor over the link or abbreviation.
+::
+
+  <a id="recommend-tor" title="How to install Tor Browser" href="{url}">Learn how to install it</a>
+
+It is necessary to translate the contents of any ``title`` attribute.
+The correctly translated HTML in Spanish would be::
+
+  <a id="recommend-tor" title="Cómo instalar Tor Browser" href="{url}">Aprenda cómo instalarlo</a>
+
+As explained above, the text content ``recommend-tor`` of the ``id``
+attribute in the ``<a>`` element should not be translated. Neither
+should the ``{url}`` placeholder of ``href`` attribute. Only the text
+content of the ``title`` attribute (``"How to install Tor Browser"``)
+should be translated.
+
+Other attributes
+""""""""""""""""
+
+No attribute other than ``alt`` and ``title`` should be translated.
+
+In particular, please make sure the attributes ``class``, ``id``,
+``height``, ``href``, ``rel``, ``src`` and ``width``
+are never translated.
 
 Reviews
 -------


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

Clarifies that both `alt` and `title` HTML attributes must be translated, and no other attribute should. Add example to demonstrate correct translations for both the `alt` and `title` tags in plausible contexts.

Also add a list of currently used HTML attributes which values should not be translated for explicitness. I tried to make clear that the list is not meant to be exhaustive, but listed all attributes currently in use in the [SecureDrop Core translations](https://github.com/freedomofpress/securedrop/blob/develop/securedrop/translations/messages.pot).

* Fixes #83


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] Please proof-read, I'm not an native English speaker :slightly_smiling_face: and don't hesitate to amend or ask me to correct where needed!

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
I don't think any special considerations are needed before releasing this change.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000