### PR TITLE
Update permanently redirected links

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -55,7 +55,7 @@ applied, you can do so through the firewall's pfSense WebGUI. Refer to our
 Upgrade Docs`_ for further details on how to update the suggested firewall.
 
 .. _`Netgate RSS Feed`: https://www.netgate.com/feed.xml
-.. _`pfSense Upgrade Docs`: https://doc.pfsense.org/index.php/Upgrade_Guide
+.. _`pfSense Upgrade Docs`: https://docs.netgate.com/pfsense/en/latest/install/upgrade-guide.html
 
 Updating the SecureDrop Workstations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -97,7 +97,7 @@ Guide <ossec_alerts>` for more information on common OSSEC alerts.
 
           |Test Alert|
 
-.. _`SecureDrop Support Portal`: https://securedrop-support.readthedocs.io/en/latest/
+.. _`SecureDrop Support Portal`: https://support-docs.securedrop.org/
 
 Common Tasks
 ------------
@@ -243,7 +243,7 @@ the *Application Server* and *Monitor Server*.
         to use ``tmux``.
 
 .. _`tmux tutorial`:
-  https://robots.thoughtbot.com/a-tmux-crash-course
+  https://thoughtbot.com/blog/a-tmux-crash-course
 
 .. tip:: If you want a refresher of the Linux command line, we recommend
   `this resource`_ to cover the fundamentals.

--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -48,7 +48,7 @@ If you find you cannot perform a backup or restore due to this constraint,
 and have already deleted old submissions from the *Journalist Interface*,
 contact us through the `SecureDrop Support Portal`_.
 
-.. _SecureDrop Support Portal: https://securedrop-support.readthedocs.io/en/latest/
+.. _SecureDrop Support Portal: https://support-docs.securedrop.org/
 
 Backing Up
 ----------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,4 +325,6 @@ linkcheck_ignore = [
     r"https://weblate.securedrop.org/accounts/profile/.*",
     r"https://github.com/freedomofpress/securedrop/issues/.*",
     r"https://github.com/freedomofpress/securedrop/tree/.*",
+    r"https://docs.securedrop.org/?$",
+    r"https://support-docs.securedrop.org/?$",
 ]

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -55,7 +55,7 @@ in common templates to ensure your page does not end up in a mixed
 HTTPS/HTTP state.
 
 Consider submitting your domain to be included in the `Chrome HSTS
-preload list <https://hstspreload.appspot.com/>`__ if you can meet all
+preload list <https://hstspreload.org/>`__ if you can meet all
 of the requirements. This will tell web browsers that the site is only
 ever to be reached over HTTPS.
 
@@ -78,7 +78,7 @@ issues it, you'll often be asked to generate the private key and a CSR
 
 When you do this, it's imperative that you use SHA-2 as the hashing
 algorithm instead of SHA-1, which is `being phased
-out <http://googleonlinesecurity.blogspot.com/2014/09/gradually-sunsetting-sha-1.html>`__.
+out <https://security.googleblog.com/2014/09/gradually-sunsetting-sha-1.html>`__.
 You should also choose a key size of *at least* 2048 bits. These
 parameters will help ensure that the encryption used on your *Landing
 Page* is sufficiently strong. The following example OpenSSL command will
@@ -254,7 +254,7 @@ Change detection monitoring for the web application configuration and *Landing P
 
 OSSEC is a free and open source host-based intrusion detection suite
 that includes a file integrity monitor. More information can be found
-`here. <https://ossec.github.io/>`__
+`here. <https://www.ossec.net/>`__
 
 Don't log access to the *Landing Page* in the webserver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -344,7 +344,7 @@ identity. Instead, use public wifi networks and devices you control.
 **Got it. How can I submit files and messages through SecureDrop?**
 
 Once you are connected to a public network at a cafe or library, download
-and install the `Tor Browser <https://www.torproject.org/projects/torbrowser>`_.
+and install the `Tor Browser <https://www.torproject.org/download/>`_.
 
 Launch Tor Browser. Visit our organization’s unique SecureDrop URL at
 **http://our-unique-URL.onion/**.

--- a/docs/development/apt_repo.rst
+++ b/docs/development/apt_repo.rst
@@ -27,7 +27,7 @@ securedrop-ossec-agent
 securedrop-ossec-server
     Installs the SecureDrop-specific OSSEC configuration for the *Monitor Server*.
 
-`securedrop-grsec <https://github.com/freedomofpress/grsec>`_
+`securedrop-grsec <https://github.com/freedomofpress/ansible-role-grsecurity>`_
     SecureDrop grsecurity kernel metapackage, depending on the latest version
     of ``linux-image-3.14-*-grsec``.
 

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -67,7 +67,7 @@ project and its components, including the graphical `SecureDrop Client <https://
 
 When you're ready to share your work with the SecureDrop team for review, submit
 a `pull request
-<https://help.github.com/categories/collaborating-with-issues-and-pull-requests/>`__
+<https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests>`__
 with the proposed changes. :doc:`Tests <testing_securedrop>` will run
 automatically on GitHub.
 
@@ -169,7 +169,7 @@ Forum Moderators and Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Those running a production instance of SecureDrop are encouraged to `read the
-support documentation <https://securedrop-support.readthedocs.io/>`__ to get
+support documentation <https://support-docs.securedrop.org/>`__ to get
 help from the `Freedom of the Press Foundation <https://freedom.press>`__. For
 less sensitive topics such as running a demo or getting help to understand a
 concept, a `public forum section <https://forum.securedrop.org/c/support>`__ is

--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -4,7 +4,7 @@ Contributing Guidelines
 Signing commits
 ---------------
 
-Commits should be signed, as `explained in the GitHub documentation <https://help.github.com/articles/signing-commits-using-gpg/>`_.
+Commits should be signed, as `explained in the GitHub documentation <https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/signing-commits>`_.
 This helps verify commits proposed in a pull request are from the expected author.
 
 Branching Strategy
@@ -88,7 +88,7 @@ HTML
 
 HTML should be in compliance with
 `Google's HTML style guide <https://google.github.io/styleguide/htmlcssguide.html>`__.
-We use `html-linter <https://pypi.python.org/pypi/html-linter/>`__ to lint
+We use `html-linter <https://pypi.org/project/html-linter/>`__ to lint
 our HTML templates in ``securedrop/source_templates`` and
 ``securedrop/journalist_templates``. Run the HTML linting options we use via:
 

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -8,7 +8,7 @@ are stored in the ``docs/`` directory of the `SecureDrop docs repository
 <https://github.com/freedomofpress/securedrop-docs>`_.
 
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
-.. _Read the Docs: https://docs.readthedocs.org/en/latest/index.html
+.. _Read the Docs: https://docs.readthedocs.io/en/latest/index.html
 
 
 Integration with Read the Docs

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -487,7 +487,7 @@ with a release looming, the server can be rebooted.
 .. _`.po`: https://www.gnu.org/software/gettext/manual/gettext.html#PO-Files
 .. _`.mo`: https://www.gnu.org/software/gettext/manual/gettext.html#MO-Files
 .. _`pybabel`: https://babel.pocoo.org/en/latest/
-.. _`Weblate`: http://weblate.securedrop.org/
+.. _`Weblate`: https://weblate.securedrop.org/
 .. _`SecureDrop git repository`: https://github.com/freedomofpress/securedrop
 .. _`Weblate SecureDrop branch`: https://github.com/freedomofpress/securedrop-i18n
 .. _`patch they contain is unique`: https://git-scm.com/docs/git-patch-id

--- a/docs/development/making_pr.rst
+++ b/docs/development/making_pr.rst
@@ -120,5 +120,5 @@ PR page and also emailed to admins.
 3. From there, a maintainer will accept your PR or they may request comments
 for you to address prior to merge. The maintainer may also ask you to `squash
 your commits
-<https://robots.thoughtbot.com/git-interactive-rebase-squash-amend-rewriting-history>`_
+<https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history>`_
 prior to merge.

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -261,7 +261,7 @@ Release Process
 #. Push your commits to the remote ``release`` branch. This will trigger an
    automatic upload of the packages to ``apt-qa.freedom.press``, but the
    packages will not yet be installable.
-#. Create a `draft PR <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests>`__
+#. Create a `draft PR <https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests>`__
    from ``release`` into ``main``. Make sure to include a link to the build
    logs in the PR description.
 #. A reviewer must verify the build logs, obtain and sign the generated ``Release``

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -70,7 +70,7 @@ macOS
 
 Install Docker_.
 
-.. _Docker: https://store.docker.com/editions/community/docker-ce-desktop-mac
+.. _Docker: https://hub.docker.com/editions/community/docker-ce-desktop-mac
 
 
 Qubes
@@ -289,9 +289,9 @@ different version, the path to ``virtualenvwrapper.sh`` will differ. Running
 
 The version of rsync installed by default on macOS is extremely out-of-date, as is Apple's custom. We recommend using Homebrew_ to install a modern version (3.1.0 or greater): ``brew install rsync``.
 
-.. _Vagrant: http://www.vagrantup.com/downloads.html
+.. _Vagrant: https://www.vagrantup.com/downloads.html
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads
-.. _Ansible: http://docs.ansible.com/intro_installation.html
+.. _Ansible: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
 .. _Homebrew: https://brew.sh/
 .. _homebrew-cask: https://sourabhbajaj.com/mac-setup/Vagrant/README.html
 

--- a/docs/development/testing_application_tests.rst
+++ b/docs/development/testing_application_tests.rst
@@ -22,7 +22,7 @@ recent Tor Browser.
 .. _`GitHub #1629`: https://github.com/freedomofpress/securedrop/pull/1629
 
 .. _Pytest: https://docs.pytest.org/en/latest/
-.. _Selenium: http://docs.seleniumhq.org/docs/
+.. _Selenium: https://www.selenium.dev/documentation/
 
 Installation
 ------------

--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -40,7 +40,7 @@ The modified value persists across restarts of Tor Browser.
 Upgrading or Adding Python Dependencies
 ---------------------------------------
 
-We use a `pip-compile <http://nvie.com/posts/better-package-management/>`_
+We use a `pip-compile <https://nvie.com/posts/better-package-management/>`_
 based workflow for adding Python dependencies. If you would like to add a Python
 dependency, instead of editing the ``securedrop/requirements/*.txt`` files
 directly, please:

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -183,7 +183,7 @@ systems. These instances use the standard TOTP and/or HOTP algorithms,
 and so a variety of devices can be used to generate 6-digit two-factor
 authentication codes. We recommend using one of:
 
--  FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ or `for iOS <https://itunes.apple.com/us/app/freeotp-authenticator/id872559395>`__ installed
--  A `YubiKey <https://www.yubico.com/products/yubikey-hardware/>`__
+-  FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ or `for iOS <https://apps.apple.com/us/app/freeotp-authenticator/id872559395>`__ installed
+-  A `YubiKey <https://www.yubico.com/products/>`__
 
 .. include:: includes/otp-app.txt

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -686,7 +686,7 @@ Network Switch
 This is optional, for people who are using a firewall with less than 4
 ports.  Any old switch with more than 3 ports will do, such as the
 `5-port Netgear ProSafe Ethernet Switch
-<http://www.amazon.com/NETGEAR-ProSafe-Gigabit-Ethernet-Desktop/dp/B0000BVYT3/>`__.
+<https://www.amazon.com/NETGEAR-Ethernet-Unmanaged-Protection-GS105NA/dp/B0000BVYT3>`__.
 
 .. _printers_tested_by_fpf:
 

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -529,7 +529,7 @@ Intel 5th-gen NUC
 ~~~~~~~~~~~~~~~~~
 
 We previously recommended the
-`NUC5i5MYHE <https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits/nuc5i5myhe.html>`__,
+`NUC5i5MYHE <https://web.archive.org/web/20190102175756/https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits/nuc5i5myhe.html>`__,
 however, it has now reached end-of-life. We will continue to support and
 test SecureDrop on this hardware, but if you are building a new SecureDrop
 instance we recommend using 7th- or 8th-generation NUCs instead.

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -171,7 +171,7 @@ SecureDrop system. Each admin and each journalist needs a two-factor
 device. We currently support two options for two-factor authentication:
 
 * Your existing smartphone with an app that computes TOTP codes
-  (e.g. FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ and `for iOS <https://itunes.apple.com/us/app/freeotp-authenticator/id872559395>`__).
+  (e.g. FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ and `for iOS <https://apps.apple.com/us/app/freeotp-authenticator/id872559395>`__).
 
 * A dedicated hardware dongle that computes HOTP codes (e.g. a
   `YubiKey <https://www.yubico.com/products/yubikey-hardware/yubikey/>`__).
@@ -336,8 +336,8 @@ easy-to-read labels, and it's easy to customize the size of the label's text,
 which is great for clearly labeling both large components (like computers) and
 small components (like USB sticks).
 
-.. _`Brother P-Touch PT-210`: https://www.amazon.com/Brother-P-Touch-PT-D210-Label-Maker/dp/B01BTMEKRQ/ref=zg_bs_226180_1
-.. _`Epson LabelWorks LW-300`: https://www.amazon.com/Epson-LabelWorks-LW-300-Label-Maker/dp/B005J7Y6HW/ref=pd_sbs_229_7
+.. _`Brother P-Touch PT-210`: https://www.amazon.com/Brother-PTD210-with-TZe2312PK-Tape/dp/B01BTMEKRQ
+.. _`Epson LabelWorks LW-300`: https://www.amazon.com/Epson-LabelWorks-LW-300-Label-C51CB69010/dp/B005J7Y6HW
 
 If you do not have a label maker available but have an inkjet printer available to you, it may
 also be possible to print and cut out labels using adhesive-backed paper and some scissors. These are some labels designed by our team which may be used for labeling:
@@ -496,7 +496,7 @@ Next, proceed with the rest of the :ref:`SecureDrop installation<nuc8_back_to_se
 Intel 7th-gen NUC
 ~~~~~~~~~~~~~~~~~
 
-We have tested and can recommend the `NUC7i5BNH <https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits/nuc7i5bnh.html>`__.
+We have tested and can recommend the `NUC7i5BNH <https://ark.intel.com/content/www/us/en/ark/products/95067/intel-nuc-kit-nuc7i5bnh.html>`__.
 
 The NUC7i5BNH has soldered-on wireless components, which cannot easily be
 removed. For security reasons, we recommend that you take the following steps
@@ -611,7 +611,7 @@ from exhaustive.
 
 We advise against using Macs, as there are many Tails compatibility issues both
 with older and with newer models. Instead, we recommend the
-`ThinkPad T series <https://www3.lenovo.com/us/en/laptops/thinkpad/thinkpad-t-series/c/thinkpadt>`__,
+`ThinkPad T series <https://www.lenovo.com/us/en/laptops/thinkpad/thinkpad-t-series/c/thinkpadt>`__,
 and have had good experiences specifically with the T420 and T440. The
 `ThinkWiki <https://www.thinkwiki.org/wiki/ThinkWiki>`__ is an excellent,
 independently maintained resource for verifying general Linux compatibility of
@@ -663,7 +663,7 @@ Anything more than that is probably overkill.
 
 Transfer Device(s) and Export Device(s)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For USB drives with physical write protection, we have tested the `Kanguru SS3 <https://www.kanguru.com/storage-accessories/kanguru-ss3.shtml>`__
+For USB drives with physical write protection, we have tested the `Kanguru SS3 <https://www.kanguru.com/storage-accessories/kanguru-ss3-high-performance-usb-flash-drive-with-physical-write-protect-switch.shtml>`__
 on Tails, and it works well with and without encryption.
 
 If you want to use a setup based on CD-Rs or DVD-Rs, we've found the CDR/DVD

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -174,7 +174,7 @@ device. We currently support two options for two-factor authentication:
   (e.g. FreeOTP `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__ and `for iOS <https://apps.apple.com/us/app/freeotp-authenticator/id872559395>`__).
 
 * A dedicated hardware dongle that computes HOTP codes (e.g. a
-  `YubiKey <https://www.yubico.com/products/yubikey-hardware/yubikey/>`__).
+  `YubiKey <https://www.yubico.com/setup/>`__).
 
 .. include:: includes/otp-app.txt
 

--- a/docs/https_source_interface.rst
+++ b/docs/https_source_interface.rst
@@ -83,10 +83,10 @@ certificate a validity period of 12 months.
    Workstation, and avoiding copying the ``.key`` to any insecure removable
    media or other computers.
 
-.. _`specific URL`: https://www.digicert.com/certcentral-support/use-http-practical-demonstration-dcv-method.htm
-.. _`DigiCert's documentation`: https://www.digicert.com/blog/ordering-a-onion-certificate-from-digicert/
+.. _`specific URL`: https://docs.digicert.com/manage-certificates/organization-domain-management/managing-domains-cc-guide/add-authorize-domain-http-dcv/
+.. _`DigiCert's documentation`: https://www.digicert.com/dc/blog/ordering-a-onion-certificate-from-digicert/
 .. |HTTPS Onion cert| image:: images/screenshots/onion-url-certificate.png
-.. _`contact DigiCert directly`: https://www.digicert.com/blog/ordering-a-onion-certificate-from-digicert/
+.. _`contact DigiCert directly`: https://www.digicert.com/dc/blog/ordering-a-onion-certificate-from-digicert/
 .. _`CAB Forum`: https://cabforum.org/2015/02/18/ballot-144-validation-rules-dot-onion-names/
 
 Activating HTTPS in SecureDrop

--- a/docs/includes/otp-app.txt
+++ b/docs/includes/otp-app.txt
@@ -1,7 +1,7 @@
 .. tip:: We recommend using FreeOTP (available `for Android <https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp>`__
-   and `for iOS <https://itunes.apple.com/us/app/freeotp-authenticator/id872559395>`__)
+   and `for iOS <https://apps.apple.com/us/app/freeotp-authenticator/id872559395>`__)
    to generate two-factor codes because it is Free Software.
    However, if it does not work for you for any reason, alternatives exist:
 
-   * Google Authenticator `for Android <https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2>`__ and `iOS <https://itunes.apple.com/us/app/google-authenticator/id388497605>`__ (proprietary)
-   * authenticator `for the desktop <https://pypi.python.org/pypi/authenticator>`__ (Free Software)
+   * Google Authenticator `for Android <https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2>`__ and `iOS <https://apps.apple.com/us/app/google-authenticator/id388497605>`__ (proprietary)
+   * authenticator `for the desktop <https://pypi.org/project/authenticator/>`__ (Free Software)

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -12,7 +12,7 @@ provide `abstract firewall rules`_ that can be implemented with iptables, Cisco
 IOS etc. This guide is based on pfSense, and assumes your firewall hardware has
 at least three interfaces: WAN, LAN, and OPT1. For hardware, you can build
 your own network firewall (not covered in this guide) and `install pfSense
-<https://doc.pfsense.org/index.php/Installing_pfSense>`__ on it. For most
+<https://docs.netgate.com/pfsense/en/latest/install/download-installer-image.html>`__ on it. For most
 installations, we recommend buying a dedicated firewall appliance with
 pfSense pre-installed, such as the one recommended in the
 :ref:`Hardware Guide <hardware_guide>`.
@@ -28,14 +28,14 @@ If you are new to pfSense or firewall management in general, we
 recommend the following resources:
 
 -  `Official pfSense
-   Wiki <https://doc.pfsense.org/index.php/Main_Page>`__
+   Wiki <https://docs.netgate.com/pfsense/en/latest/index.html>`__
 -  `pfSense: The Definitive
    Guide <https://www.amazon.com/pfSense-Definitive-Christopher-M-Buechler/dp/0979034280>`__
 
    -  *Note:* This guide is now slightly out of date, although we found
       it to be a useful reference in the past. To get the latest version of
       this book, you need to become a `pfSense Gold
-      Member <https://www.pfsense.org/our-services/gold-membership.html>`__.
+      Member <https://www.pfsense.org/our-services/#gold-membership>`__.
 
 If you're using the recommended SG-3100 firewall, then you may find the
 following resource useful. In particular, you can find instructions on factory

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -25,17 +25,10 @@ obtain a separate switch to connect the *Admin Workstation* for the initial
 installation.
 
 If you are new to pfSense or firewall management in general, we
-recommend the following resources:
+recommend the following resource:
 
 -  `Official pfSense
    Wiki <https://docs.netgate.com/pfsense/en/latest/index.html>`__
--  `pfSense: The Definitive
-   Guide <https://www.amazon.com/pfSense-Definitive-Christopher-M-Buechler/dp/0979034280>`__
-
-   -  *Note:* This guide is now slightly out of date, although we found
-      it to be a useful reference in the past. To get the latest version of
-      this book, you need to become a `pfSense Gold
-      Member <https://www.pfsense.org/our-services/#gold-membership>`__.
 
 If you're using the recommended SG-3100 firewall, then you may find the
 following resource useful. In particular, you can find instructions on factory

--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -549,7 +549,7 @@ This alert is common but if you see them for sustained periods of time (several
 times a day), please contact us at the `SecureDrop Support Portal`_ or at
 securedrop@freedom.press for help.
 
-.. _SecureDrop Support Portal: https://securedrop-support.readthedocs.io/en/latest/
+.. _SecureDrop Support Portal: https://support-docs.securedrop.org/
 
 Daily reports
 ^^^^^^^^^^^^^

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -31,7 +31,7 @@ SecureDrop application environment consists of three dedicated computers:
    download encrypted documents and respond to sources.
 - *Monitor Server*:
    An Ubuntu server that monitors the *Application Server*
-   with `OSSEC <https://ossec.github.io/>`__ and sends email alerts.
+   with `OSSEC <https://www.ossec.net/>`__ and sends email alerts.
 
 These computers should all physically be in your organization's office.
 
@@ -91,13 +91,13 @@ newsrooms, there may be a team of systems admins. The admin
 uses a dedicated *Admin Workstation* running `Tails <https://tails.boum.org>`__,
 connects to the *Application* and *Monitor Servers* over  `authenticated onion services
 <https://tb-manual.torproject.org/onion-services/>`__, and manages them
-using `Ansible <http://www.ansible.com/>`__.
+using `Ansible <https://www.ansible.com/>`__.
 
 Sources
 ~~~~~~~
 
 A source submits documents and messages by using `Tor Browser
-<https://www.torproject.org/projects/torbrowser.html>`__ (or Tails) to access
+<https://www.torproject.org/download/>`__ (or Tails) to access
 the *Source Interface*: a public onion service. Submissions are encrypted
 in place on the *Application Server* as they are uploaded.
 

--- a/docs/rebuild_admin.rst
+++ b/docs/rebuild_admin.rst
@@ -6,7 +6,7 @@ Rebuilding an *Admin Workstation* USB
           rebuild your *Admin Workstation*, please contact FPF through the
           `SecureDrop Support Portal`_.
 
-.. _SecureDrop Support Portal: https://securedrop-support.readthedocs.io/en/latest/
+.. _SecureDrop Support Portal: https://support-docs.securedrop.org/
 
 
 In cases where an *Admin Workstation* USB stick has been lost or destroyed, and no

--- a/docs/set_up_svs.rst
+++ b/docs/set_up_svs.rst
@@ -20,7 +20,7 @@ safer approach, fill a port with epoxy to physically disable it. We also
 recommend you remove the speakers from the device (or just cut the audio cables
 if that's easier). This is to prevent `exfiltration of data from the airgap via
 ultrasonic audio
-<https://arstechnica.com/security/2013/12/scientist-developed-malware-covertly-jumps-air-gaps-using-inaudible-sound/>`__,
+<https://arstechnica.com/information-technology/2013/12/scientist-developed-malware-covertly-jumps-air-gaps-using-inaudible-sound/>`__,
 which cannot be heard by humans. If you have questions about repurposing
 hardware for the *Secure Viewing Station*, contact the `Freedom of the Press
 Foundation <https://securedrop.org/help>`__.

--- a/docs/threat_model/threat_model.rst
+++ b/docs/threat_model/threat_model.rst
@@ -647,7 +647,7 @@ What a Local Network Attacker Can Achieve Against the Source, Admin, or Journali
 -  A local network may be able to deduce use of SecureDrop by looking at
    request sizes, plaintext uploads and encrypted downloads, although
    `research suggests this is very
-   difficult <https://blog.torproject.org/blog/critique-website-traffic-fingerprinting-attacks>`__.
+   difficult <https://blog.torproject.org/critique-website-traffic-fingerprinting-attacks>`__.
 
 What a Global Adversary Can Achieve Against the Source, Admin, or Journalist:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/update_tails_usbs.rst
+++ b/docs/update_tails_usbs.rst
@@ -94,4 +94,4 @@ If you run into issues, you can always restore your data from the backup device 
 
 If you continue to have problems, you can contact us through the `SecureDrop Support Portal`_.
 
-.. _SecureDrop Support Portal: https://securedrop-support.readthedocs.io/en/latest/
+.. _SecureDrop Support Portal: https://support-docs.securedrop.org/

--- a/docs/upgrade/1.4.0_to_1.4.1.rst
+++ b/docs/upgrade/1.4.0_to_1.4.1.rst
@@ -13,7 +13,7 @@ Using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
 the *SecureDrop Workstation Updater* will alert you to workstation updates. You
-must have `configured an administrator password <https://tails.boum.org/doc/first_steps/startup_options/administration_password/>`_
+must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
 Perform the update to 1.4.1 by clicking "Update Now":

--- a/docs/upgrade/1.4.1_to_1.5.0.rst
+++ b/docs/upgrade/1.4.1_to_1.5.0.rst
@@ -13,7 +13,7 @@ Using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
 the *SecureDrop Workstation Updater* will alert you to workstation updates. You
-must have `configured an administrator password <https://tails.boum.org/doc/first_steps/startup_options/administration_password/>`_
+must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
 Perform the update to 1.5.0 by clicking "Update Now":

--- a/docs/upgrade/1.5.0_to_1.6.0.rst
+++ b/docs/upgrade/1.5.0_to_1.6.0.rst
@@ -14,7 +14,7 @@ Using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
 the *SecureDrop Workstation Updater* will alert you to workstation updates. You
-must have `configured an administrator password <https://tails.boum.org/doc/first_steps/startup_options/administration_password/>`_
+must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
 Perform the update to 1.6.0 by clicking "Update Now":

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -67,7 +67,7 @@ Enabling v3 onion services will have the following effects:
           process
           without first disabling HTTPS for v2. 
 
-.. _SecureDrop Support Portal: https://securedrop-support.readthedocs.io/en/latest/
+.. _SecureDrop Support Portal: https://support-docs.securedrop.org/
 .. _our GPG key: https://securedrop.org/sites/default/files/fpf-email.asc
 
 

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -17,7 +17,7 @@ are made by a company called Yubico and are `commercially available`_. Note
 that not all physical tokens are compatible with the YubiKey Personalization
 Tool; for this, you require `a key that can support OATH-HOTP`_.
 
-.. _`commercially available`: https://www.yubico.com/products/yubikey-hardware/fido-u2f-security-key
+.. _`commercially available`: https://www.yubico.com/authentication-standards/fido-u2f/
 
 .. _`a key that can support OATH-HOTP`: https://support.yubico.com/hc/en-us/articles/360016614780-OATH-HOTP-Yubico-Best-Practices-Guide
 


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->
Ready for review

## Description of Changes

Updates the links that are flagged as **redirected permanently** by `make docs-linkcheck`, in order to reduce the amount of warnings in the output of the tool.

* Fixes #124 

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] Review that _each_ link points to the same place as before. :grimacing: There are a lot of them, but I can't think of a better way to review that looking at them one by one.
- [ ] Review the decisions made for the few broken links (e.g. the link to the NUC5i5MYHE kit that doesn't seem to be documented by Intel anymore)

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
- [ ] Run `make linkcheck`
- [ ] Preview the docs locally and verify that the links are rendered as expected

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000