### PR TITLE
 Fix broken link to page of historical relevance (2)

### DIFF
--- a/docs/getting_the_most_out_of_securedrop.rst
+++ b/docs/getting_the_most_out_of_securedrop.rst
@@ -91,7 +91,7 @@ proof of concept Twitter advertisement aimed at EPA and NOAA employees to show
 how it can be done. You can read about `how you can do the same thing here`_.
 
 .. _`recently targeted online advertisements`: https://www.wsj.com/articles/gizmodo-ads-target-potential-trump-leakers-1487191482
-.. _`tell on trump`: https://web.archive.org/web/20201114212453/https://specialprojectsdesk.com/tell-on-trump-1792401813
+.. _`tell on trump`: https://web.archive.org/web/20200926063152/https://specialprojectsdesk.com/tell-on-trump-1792401813
 .. _`how you can do the same thing here`: https://freedom.press/news/we-targeted-securedrop-ad-potential-whistleblowers-trump-administration-you-can-too/
 
 Put an Advertisement in Your Physical Paper


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

This PR is a follow up on #118. I misspelled the timestamp in the link :disappointed: 

Fixes #126 

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] This time, when running `make docs-linkcheck` the logs should report `ok` instead of `redirect / found`.
```
(line   86) ok        https://web.archive.org/web/20200926063152/https://specialprojectsdesk.com/tell-on-trump-1792401813
```

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
I can't think of any special consideration before releasing this change.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed  (not only passed but doesn't report the tell-tale redirect)
- [x] You have previewed (`make docs`) docs at http://localhost:8000