### PR TITLE
docs: update the list of supported languages

### DIFF
--- a/docs/includes/l10n.txt
+++ b/docs/includes/l10n.txt
@@ -18,4 +18,5 @@
 * Slovak (``sk``)
 * Swedish (``sv``)
 * Turkish (``tr``)
+* Chinese, Simplified (``zh_Hans``)
 * Chinese, Traditional (``zh_Hant``)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds simplified Chinese to the list of supported languages.

## Testing

Run `make docs`, visit http://localhost:8000/admin.html#configuring-localization-for-the-source-interface-and-the-journalist-interface and verify that `Chinese, Simplified (zh_Hans)` is listed.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000