### PR TITLE
Clarify which dev-shell is used for securedrop-admin

### DIFF
--- a/docs/development/admin_development.rst
+++ b/docs/development/admin_development.rst
@@ -1,9 +1,9 @@
 Development of Securedrop-Admin in the Admin Directory
 ======================================================
 
-The ``admin`` directory contains the source of the
-``securedrop-admin`` script which is used in Tails to perform various
-administrative tasks. It is a standalone python module which can be
+The ``admin`` directory in the SecureDrop repository root contains the
+source of the ``securedrop-admin`` script which is used in Tails to perform
+various administrative tasks. It is a standalone python module which can be
 tested on Debian GNU/Linux stretch with:
 
 .. code::
@@ -13,8 +13,17 @@ tested on Debian GNU/Linux stretch with:
    pip3 install --no-deps --require-hashes -r requirements-dev.txt
    tox
 
-A Docker helper is provided to simplify the installation and make
-it portable on various operating systems.
+A Docker helper ``bin/dev-shell`` is provided to simplify the installation
+and make it portable on various operating systems. From the ``admin`` directory,
+run ``bin/dev-shell`` without any arguments to execute ``securedrop-admin`` or
+other  commands interactively in the container. If this is your first time
+running ``bin/dev-shell``, it may take several minutes to build the image.
+
+.. note::
+
+   The SecureDrop repository contains two scripts named ``dev-shell``.
+   ``admin/bin/dev-shell`` is used for ``securedrop-admin`` while
+   ``securedrop/bin/dev-shell`` is used for the server environment.
 
 Run only flake8 with:
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Provides some clarification given the potentially confusing presence of two different `bin/dev-shell` commands in the same repository.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000