### PR TITLE
Update server installation instructions to use Focal instead of Xenial

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -390,14 +390,6 @@ Intel 8th-gen NUC
 We have tested and can recommend the `NUC8i5BEK <https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits/nuc8i5bek.html>`__.
 It provides a single storage option: an M.2 NVMe or SATA SSD.
 
-.. note:: The Ubuntu 16.04 install kernel does not support the NUC8's built-in
-  Ethernet NIC, so a 16.04-compatible USB Ethernet adaptor is required for the
-  OS installation. The Ethernet adaptor will not be needed after the
-  installation is complete, as SecureDrop's custom kernel does support the
-  built-in NIC.
-
-  For more information on the NUC8-specific steps required during the OS install, see :ref:`nuc8_enable_network`.
-
 The NUC8i5BEK has soldered-on wireless components, which cannot easily be
 removed. For security reasons, we recommend that you take the following steps
 to disable wireless functionality:
@@ -426,73 +418,6 @@ to disable wireless functionality:
 .. |NUC8 VisualBIOS1| image:: images/hardware/nuc8_visualbios1.png
 .. |NUC8 VisualBIOS2| image:: images/hardware/nuc8_visualbios2.png
 .. |NUC8 VisualBIOS SecureBoot| image:: images/hardware/nuc8_visualbios_secureboot.png
-
-.. _nuc8_enable_network:
-
-Enabling Network Support for the NUC8i5BEK
-******************************************
-
-The Ubuntu 16.04 installer uses a 4.4-series Linux kernel, which does not include
-support for the NUC8-series built-in NIC. In order to complete the Ubuntu OS
-install on the SecureDrop servers, a USB Ethernet adaptor that is supported by
-the install may be used. The adaptor should not be used as part of the final
-system setup, however. Instead, before installing SecureDrop, the Ubuntu kernel
-should be updated to a version with support for the built-in NIC, and the
-network configuration should be updated to use it instead of the USB adaptor.
-
-To do so, after rebooting the server following the initial Ubuntu install,
-follow the steps below:
-
-#. Log in at the console as the admin user created during the initial install.
-#. Verify that the server is using a 4.4-series kernel with the command ``uname -r``.
-#. Check the USB adaptor's interface name with the command ``ip link show`` - it
-   should list two network interfaces: the loopback device ``lo``, and an interface
-   with a longer name - the latter is the USB adaptor's interface name.
-#. Upgrade to the Ubuntu 16.04 HWE kernel using the following commands:
-
-   .. code:: sh
-
-     sudo apt-get update
-     sudo apt-get dist-upgrade
-     sudo apt install --install-recommends linux-generic-hwe-16.04
-
-#. Reboot the system, log in at the console,  and verify that it is now running
-   a 4.15-series kernel with the command ``uname -r``
-#. Verify that the built-in NIC is now enabled via ``ip link show``. There
-   should now be 3 devices listed, ``lo``, the adaptor interface, and ``eno1``,
-   the interface name of the built-in NIC.
-#. Edit the network interface configuration file with the command:
-
-   .. code:: sh
-
-     sudo vi /etc/network/interfaces
-
-   Note the two references to the USB adaptor interface name in the lines:
-
-   .. code-block:: none
-
-     # the primary network interface
-     auto <USB adaptor interface name>
-     iface <USB adaptor interface name> inet static
-
-   Update them to read as follows:
-
-   .. code-block:: none
-
-     # the primary network interface
-     auto eno1
-     iface eno1 inet static
-
-
-   Then save the changes, disconnect the Ethernet cable from the USB adaptor,
-   connect the cable to the onboard Ethernet port, disconnect the adaptor,
-   and reboot the system.
-
-#. Log in and verify that  ``lo`` and ``eno1`` are the only interfaces listed, via ``ip link
-   show``, and that external connectivity is working, via ``curl -I www.google.com``
-   for example.
-
-Next, proceed with the rest of the :ref:`SecureDrop installation<nuc8_back_to_setup>`.
 
 .. _nuc7_recommendation:
 

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -6,11 +6,11 @@ Install Ubuntu
 --------------
 
 .. note:: Installing Ubuntu is simple and may even be something you are very familiar
-  with, but we **strongly** encourage you to read and follow this documentation
+  with, but it is **strongly** encouraged that youread and follow this documentation
   exactly as there are some "gotchas" that may cause your SecureDrop setup to break.
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-20.04.2 LTS (Focal Fosse)**. To install Ubuntu on the servers, you must first
+20.04.2 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media. You should use the *Admin
 Workstation* to download and verify the Ubuntu installation media.
 
@@ -28,10 +28,9 @@ The installation media and the files required to verify it are available on the
 
 If you're reading this documentation in Tor Browser on the *Admin
 Workstation*, you can just click the links above and follow the prompts to save
-them to your Admin Workstation. We recommend saving them to the
-``/home/amnesia/Persistent/Tor Browser`` directory on the *Admin Workstation*,
-because it can be useful to have a copy of the installation media readily
-available.
+them to your Admin Workstation. Save them to the ``/home/amnesia/Persistent/Tor Browser``
+directory on the *Admin Workstation*, because it can be useful to have a copy of
+the installation media readily available.
 
 Alternatively, you can use the command line:
 
@@ -53,10 +52,10 @@ Verify the Ubuntu Installation Media
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You should verify the Ubuntu image you downloaded hasn't been modified by
-a malicious attacker or otherwise corrupted. We can do so by checking its
-integrity with cryptographic signatures and hashes.
+a malicious attacker or otherwise corrupted. To do so, check its integrity with
+cryptographic signatures and hashes.
 
-First, we will download both *Ubuntu Image Signing Keys* and verify their
+First, download both *Ubuntu Image Signing Keys* and verify their
 fingerprints. ::
 
     gpg --recv-key --keyserver hkps://keyserver.ubuntu.com \
@@ -64,7 +63,7 @@ fingerprints. ::
     "8439 38DF 228D 22F7 B374 2BC0 D94A A3F0 EFE2 1092"
 
 .. note:: It is important you type this out correctly. If you are not
-          copy-pasting this command, we recommend you double-check you have
+          copy-pasting this command, double-check you have
           entered it correctly before pressing enter.
 
 Again, when passing the full public key fingerprint to the ``--recv-key`` command, GPG
@@ -108,11 +107,10 @@ Create the Ubuntu Installation Media
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To create the Ubuntu installation media, you can either burn the ISO image to a
-CD-R or create a bootable USB stick.  As a reliable method we recommend using
-the ``dd`` command to copy the hybrid ISO directly to a USB drive rather than a
-utility like UNetbootin which can result in errors. Once you have a CD or USB
-with an ISO image of Ubuntu on it, you may begin the Ubuntu installation on both
-SecureDrop servers.
+CD-R or create a bootable USB stick.  The ``dd`` command can be used to copy the
+hybrid ISO directly to a USB drive, instead of a utility like UNetbootin which
+can result in errors. Once you have a CD or USB with an ISO image of Ubuntu on
+it, you may begin the Ubuntu installation on both SecureDrop servers.
 
 To use `dd` you first need to find where the USB device you wish to install
 Ubuntu on has been mapped. Simply running the command ``lsblk`` in the terminal
@@ -159,7 +157,8 @@ available, corresponding to its Ethernet, usually named ``eno1``. Select its lis
 entry using the arrow keys and press **Enter**, then select **Edit IPv4** and press
 **Enter** again.
 
-The **Edit eno1 IPv4 configuration** dialog will be displayed. In the **IPv4 Method** menu, select **Manual**, then add your server-specific settings.
+The **Edit eno1 IPv4 configuration** dialog will be displayed. In the
+**IPv4 Method** menu, select **Manual**, then add your server-specific settings.
 
 .. note:: For a production install with a pfSense network firewall in place, the
   *Application Server* and the *Monitor Server* are on separate networks.
@@ -195,32 +194,21 @@ screens should not need to be changed. Select **Done** for both.
 Full Disk Encryption - pros and cons
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Before setting up the server's disk partitions and filesystems in the
-next step, you will need to decide if you would like to enable `Full
-Disk Encryption
-(FDE) <https://www.eff.org/deeplinks/2012/11/privacy-ubuntu-1210-full-disk-encryption>`__.
-If the servers are ever powered down, FDE will ensure all of the
-information on them stays private in case they are seized or stolen.
+The use of `Full Disk Encryption (FDE)
+<https://www.eff.org/deeplinks/2012/11/privacy-ubuntu-1210-full-disk-encryption>`__
+with SecureDrop is **not recommended**. While FDE does offer data protection for
+devices that are powered down, SecureDrop's servers are designed to be always-on,
+with the exception of a nightly reboot after automatic upgrades are applied.
+Given this update schedule, with FDE enabled, the servers would become unreachable
+once every 24 hours until an administrator entered the full-disk encryption
+passphrase via the console, and during that time, sources and journalists would
+be unable to access your instance.
 
-.. warning:: The Ansible playbooks for SecureDrop will configure automatic
-             updates via ``unattended-upgrades``. As part of the automatic update
-             process, the servers will reboot nightly..
-             Using FDE would therefore require manual intervention every morning.
-             Consequently **we strongly discourage the use of FDE.**
-
-While FDE can be useful in some cases, we currently do not recommend
-that you enable it because there are not many scenarios where it will be
-a net security benefit for SecureDrop operators. Doing so will introduce
-the need for more passphrases and add even more responsibility on the
-admin of the system (see `this GitHub
-issue <https://github.com/freedomofpress/securedrop/issues/511#issuecomment-50823554>`__
-for more information).
-
-If you decide to go ahead and enable FDE, please note that
-doing so means your SecureDrop instance will become unreachable after an
-automatic reboot. An admin will need to be on hand to enter the passphrase
-in order to decrypt the disks and complete the startup process, which
-will occur after every nightly software update.
+The increased responsibility for administrators, as well as the daily downtime
+and limited scenarios in which FDE would be a net security benefit, inform this
+recommendation, but you may make a decision based on your own requirements.
+(See this `GitHub issue <https://github.com/freedomofpress/securedrop/issues/511#issuecomment-50823554>`_
+for more information.)
 
 Setting up storage
 ~~~~~~~~~~~~~~~~~~
@@ -241,7 +229,9 @@ choose **Continue** on the **Confirm destructive action** dialog.
 Configure account and hostname
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-On the **Profile setup** screen, configure the server's hostname and the administration account:
+On the **Profile setup** screen, configure the server's hostname and the administration account.
+The administrator account username and password should be the same for both
+servers:
 
 - **Your name:** Specify the administrator account name, e.g. ``SecureDrop Admin``
 - **Your server's name:** Use ``app`` for the *Application Server*, and ``mon`` for
@@ -314,7 +304,7 @@ Set Up SSH Keys
 
 Ubuntu's default SSH configuration authenticates users with their
 passphrases; however, public key authentication is more secure, and once
-it's set up it is also easier to use. In this section, we will create
+it's set up it is also easier to use. In this section, you will create
 a new SSH key for authenticating to both servers. Since the *Admin
 Workstation* was set up with `SSH Client Persistence`_, this key will be saved
 on the *Admin Workstation* and can be used in the future to authenticate to

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -105,7 +105,7 @@ Next, verify the ``SHA256SUMS`` file. ::
 
     gpg --keyid-format long --verify SHA256SUMS.gpg SHA256SUMS
 
-Move on to the next step if you see "Good Signature" twice in the output, as
+Move on to the next step if you see "Good Signature" in the output, as
 below. Note that any other message (such as "Can't check signature: no public
 key") means that you are not ready to proceed. ::
 
@@ -145,7 +145,8 @@ drives and USB). If the USB you are writing the Ubuntu installer to is of a
 different size or brand than the USB you are running Tails from, it should be
 easy to identify which USB has which sdX identifier. If you are unsure, try
 running ``lsblk`` before and after plugging in the USB you are using for the
-Ubuntu installer.
+Ubuntu installer. Note that you should use the main block device (e.g. ``/dev/sdb``)
+rather than any listed partitions (e.g. ``/dev/sdb2``).
 
 If your USB is mapped to /dev/sdX and you are currently in the directory that
 contains the Ubuntu ISO, you would use dd like so: ::

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -5,16 +5,12 @@ Set Up the Servers
 Install Ubuntu
 --------------
 
-.. caution:: Please ensure you are using the most recent Ubuntu Xenial ISO image.
-    Ubuntu Xenial ISO images 16.04.5 and lower ship with a version of the `apt` package
-    vulnerable to CVE-2019-3462.
-
 .. note:: Installing Ubuntu is simple and may even be something you are very familiar
   with, but we **strongly** encourage you to read and follow this documentation
-  exactly as there are some "gotchas" that may cause your SecureDrop set up to break.
+  exactly as there are some "gotchas" that may cause your SecureDrop setup to break.
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-16.04.7 LTS (Xenial Xerus)**. To install Ubuntu on the servers, you must first
+20.04.2 LTS (Focal Fosse)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media. You should use the *Admin
 Workstation* to download and verify the Ubuntu installation media.
 
@@ -26,7 +22,7 @@ Download the Ubuntu Installation Media
 The installation media and the files required to verify it are available on the
 `Ubuntu Releases page`_. You will need to download the following files:
 
-* `ubuntu-16.04.7-server-amd64.iso`_
+* `ubuntu-20.04.2-live-server-amd64.iso`_
 * `SHA256SUMS`_
 * `SHA256SUMS.gpg`_
 
@@ -42,16 +38,16 @@ Alternatively, you can use the command line:
 .. code:: sh
 
    cd ~/Persistent
-   torify curl -OOO https://releases.ubuntu.com/16.04.7/{ubuntu-16.04.7-server-amd64.iso,SHA256SUMS{,.gpg}}
+   torify curl -OOO https://releases.ubuntu.com/20.04.2/{ubuntu-20.04.2-live-server-amd64.iso,SHA256SUMS{,.gpg}}
 
 .. note:: Downloading Ubuntu on the *Admin Workstation* can take a while
    because Tails does everything over Tor, and Tor is typically slow relative
    to the speed of your upstream Internet connection.
 
 .. _Ubuntu Releases page: https://releases.ubuntu.com/
-.. _ubuntu-16.04.7-server-amd64.iso: https://releases.ubuntu.com/16.04.7/ubuntu-16.04.7-server-amd64.iso
-.. _SHA256SUMS: https://releases.ubuntu.com/16.04.7/SHA256SUMS
-.. _SHA256SUMS.gpg: https://releases.ubuntu.com/16.04.7/SHA256SUMS.gpg
+.. _ubuntu-20.04.2-live-server-amd64.iso: https://releases.ubuntu.com/20.04/ubuntu-20.04.2-live-server-amd64.iso
+.. _SHA256SUMS: https://releases.ubuntu.com/20.04/SHA256SUMS
+.. _SHA256SUMS.gpg: https://releases.ubuntu.com/20.04/SHA256SUMS.gpg
 
 Verify the Ubuntu Installation Media
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -88,32 +84,21 @@ Move on to the next step if you see "Good Signature" twice in the output, as
 below. Note that any other message (such as "Can't check signature: no public
 key") means that you are not ready to proceed. ::
 
-    gpg: Signature made Wed Nov 11 20:08:10 2015 GMT
-                    using DSA key ID 46181433FBB75451
-    gpg: Good signature from "Ubuntu CD Image Automatic Signing Key
-    <cdimage@ubuntu.com>"
+    gpg: Signature made Thu 11 Feb 2021 02:07:58 PM EST
+    gpg:                using RSA key 843938DF228D22F7B3742BC0D94AA3F0EFE21092
+    gpg: Good signature from "Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>" [unknown]
     gpg: WARNING: This key is not certified with a trusted signature!
-    gpg:          There is no indication that the signature belongs to the
-    owner.
-    Primary key fingerprint: C598 6B4F 1257 FFA8 6632  CBA7 4618 1433 FBB7 5451
-    gpg: Signature made Wed Nov 11 20:08:10 2015 GMT
-                    using RSA key ID D94AA3F0EFE21092
-    gpg: Good signature from "Ubuntu CD Image Automatic Signing Key (2012)
-    <cdimage@ubuntu.com>"
-    gpg: WARNING: This key is not certified with a trusted signature!
-    gpg:          There is no indication that the signature belongs to the
-    owner.
+    gpg:          There is no indication that the signature belongs to the owner.
     Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092
 
 The next and final step is to verify the Ubuntu image. ::
 
-    sha256sum -c <(grep ubuntu-16.04.7-server-amd64.iso SHA256SUMS)
-
+    sha256sum -c <(grep ubuntu-20.04.2-live-server-amd64.iso SHA256SUMS)
 
 If the final verification step is successful, you should see the
 following output in your terminal. ::
 
-    ubuntu-16.04.7-server-amd64.iso: OK
+    ubuntu-20.04.2-live-server-amd64.iso: OK
 
 .. caution:: If you do not see the line above it is not safe to proceed with the
              installation. If this happens, please contact us at
@@ -141,7 +126,7 @@ Ubuntu installer.
 If your USB is mapped to /dev/sdX and you are currently in the directory that
 contains the Ubuntu ISO, you would use dd like so: ::
 
-   sudo dd conv=fdatasync if=ubuntu-16.04.7-server-amd64.iso of=/dev/sdX
+   sudo dd conv=fdatasync if=ubuntu-20.04.2-live-server-amd64.iso of=/dev/sdX
 
 .. _install_ubuntu:
 
@@ -150,10 +135,6 @@ Perform the Installation
 
 The steps below are the same for both the *Application Server* and the
 *Monitor Server*.
-
-.. note:: If you're installing Ubuntu 16.04 on a NUC8, you will need a 16.04-compatible
-  USB Ethernet adaptor attached to complete the steps below. See the
-  :ref:`nuc8_recommendation` notes in the recommended hardware list for more information.
 
 Start by inserting the Ubuntu installation media into the server. Boot
 or reboot the server with the installation media inserted, and enter the
@@ -166,32 +147,25 @@ installation media (USB or CD) and press Enter to boot it.
 
 After booting the Ubuntu image, select **Install Ubuntu Server**.
 
-|Ubuntu Server|
-
 Follow the steps to select your language, country and keyboard settings.
 Once that's done, let the installation process continue.
 
-Configure the Network Manually
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Configure the Network
+~~~~~~~~~~~~~~~~~~~~~
 
-The Ubuntu installer will try to autoconfigure networking for the server
-you are setting up; however, SecureDrop requires manual network
-configuration. You can hit **Cancel** at any point during network
-autoconfiguration to be given the choice to *Configure the network
-manually*.
+On the **Network conections** screen, the installer will ask you to configure
+at least one interface for use by the server. Your server should only have one
+available, corresponding to its Ethernet, usually named ``eno1``. Select its list
+entry using the arrow keys and press **Enter**, then select **Edit IPv4** and press
+**Enter** again.
 
-If network autoconfiguration completes before you can do this, the next
-window will ask for your hostname. To get back to the choice of
-configuring the network manually, **Cancel** the step that asks you to
-set a hostname and choose the menu option that says **Configure the
-network manually** instead.
+The **Edit eno1 IPv4 configuration** dialog will be displayed. In the **IPv4 Method** menu, select **Manual**, then add your server-specific settings.
 
-For a production install with a pfSense network firewall in place, the
-*Application Server* and the *Monitor Server* are on separate networks.
-You may choose your own network settings at this point, but make sure
-the settings you choose are unique on the firewall's network and
-remember to propagate your choices through the rest of the installation
-process.
+.. note:: For a production install with a pfSense network firewall in place, the
+  *Application Server* and the *Monitor Server* are on separate networks.
+  You may choose your own network settings at this point, but make sure
+  the settings you choose are unique on the firewall's network and
+  remember to propagate your choices through the rest of the installation process.
 
 Below are the configurations you should enter, assuming you used the
 network settings from the network firewall guide for a 3 NIC or 4 NIC firewall.
@@ -199,35 +173,27 @@ If you did not, adjust these settings accordingly.
 
 -  *Application Server*:
 
-  -  Server IP address: 10.20.2.2
-  -  Netmask (default is fine): 255.255.255.0
-  -  Gateway: 10.20.2.1
-  -  For DNS, use Google's name servers: 8.8.8.8 and 8.8.4.4
-  -  Hostname: app
-  -  Domain name should be left blank
+  -  **Subnet:** 10.20.2.0/24
+  -  **Address:** 10.20.2.2
+  -  **Gateway:** 10.20.2.1
+  -  **Name servers:** 8.8.8.8, 8.8.4.4
+  -  **Search Domains:** *should be left blank*
 
 -  *Monitor Server*:
 
-  -  Server IP address: 10.20.3.2
-  -  Netmask (default is fine): 255.255.255.0
-  -  Gateway: 10.20.3.1
-  -  For DNS, use Google's name servers: 8.8.8.8 and 8.8.4.4
-  -  Hostname: mon
-  -  Domain name should be left blank
+  -  **Subnet:** 10.20.3.0/24
+  -  **Address:** 10.20.3.2
+  -  **Gateway:** 10.20.3.1
+  -  **Name servers:** 8.8.8.8, 8.8.4.4
+  -  **Search Domains:** *should be left blank*
 
-Continue the Installation
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Select **Save** and press **Enter** to apply your settings. Then select **Done** and press **Enter**.
 
-You can choose whatever username and passphrase you would like. To make
-things easier later you should use the same username and same passphrase
-on both servers (but not the same passphrase as username). Make sure to
-save this passphrase in your admin KeePassXC database afterwards.
+The default values on the **Configure Proxy** and **Configure Ubuntu archive mirror**
+screens should not need to be changed. Select **Done** for both.
 
-Click 'no' when asked to encrypt the home directory. Then configure your
-time zone.
-
-Partition the Disks
-~~~~~~~~~~~~~~~~~~~
+Full Disk Encryption - pros and cons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Before setting up the server's disk partitions and filesystems in the
 next step, you will need to decide if you would like to enable `Full
@@ -236,7 +202,9 @@ Disk Encryption
 If the servers are ever powered down, FDE will ensure all of the
 information on them stays private in case they are seized or stolen.
 
-.. warning:: The Ansible playbooks for SecureDrop will enable nightly reboots.
+.. warning:: The Ansible playbooks for SecureDrop will configure automatic
+             updates via ``unattended-upgrades``. As part of the automatic update
+             process, the servers will reboot nightly..
              Using FDE would therefore require manual intervention every morning.
              Consequently **we strongly discourage the use of FDE.**
 
@@ -248,64 +216,59 @@ admin of the system (see `this GitHub
 issue <https://github.com/freedomofpress/securedrop/issues/511#issuecomment-50823554>`__
 for more information).
 
-If you wish to proceed without FDE as recommended, choose the
-installation option that says *Guided - use entire disk and set up LVM*.
-
-However, if you decide to go ahead and enable FDE, please note that
-doing so means SecureDrop will become unreachable after an automatic
-reboot. An admin will need to be on hand to enter the passphrase
+If you decide to go ahead and enable FDE, please note that
+doing so means your SecureDrop instance will become unreachable after an
+automatic reboot. An admin will need to be on hand to enter the passphrase
 in order to decrypt the disks and complete the startup process, which
-will occur anytime there is an automatic software update, and also
-several times during SecureDrop's installation. We recommend that the
-servers be integrated with a monitoring solution so that you receive
-an alert when the system becomes unavailable.
+will occur after every nightly software update.
 
-To enable FDE, select *Guided - use entire disk and set up encrypted
-LVM* during the disk partitioning step and write the changes to disk.
-Follow the recommendations as to choosing a strong passphrase. As the
-admin, you will be responsible for keeping this passphrase safe.
-Write it down somewhere and memorize it if you can. **If inadvertently
-lost it could result in total loss of the SecureDrop system.**
+Setting up storage
+~~~~~~~~~~~~~~~~~~
 
-After selecting either of those options you may be asked a few questions
-about overwriting anything currently on the server you are using. Select
-yes. You do not need an HTTP proxy, so when asked, you can just click
-continue.
+On the **Guided storage configuration** screen, verify that **Use an entire disk**
+is checked, and that the server's local disk is selected. Also verify that **Set
+up this disk as an LVM group** is selected.
 
-Finish the Installation
+If you decided to set up FDE, despite the implications for administration overhead,
+select **Encrypt the LVM group with LUKS**, and enter and confirm the disk passphrase.
+Store this passphrase securely, as it will be required to unlock storage on every reboot.
+
+Select **Done** and press **Enter** to move to the **Storage Configuration** screen.
+Review the configuration and select **Done** and press **Enter** to continue. Then,
+choose **Continue** on the **Confirm destructive action** dialog.
+
+
+Configure account and hostname
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On the **Profile setup** screen, configure the server's hostname and the administration account:
+
+- **Your name:** Specify the administrator account name, e.g. ``SecureDrop Admin``
+- **Your server's name:** Use ``app`` for the *Application Server*, and ``mon`` for
+  the *Monitor Server*
+- **Pick a username:** Specify the administrator account username, e.g. ``sdadmin``
+- **Choose a password:** Specify a strong password for the administrator account.
+  A Diceware-generated passphrase is recommended.
+- **Confirm your password:** Enter the password chosen above.
+
+Select **Done** and press **Enter** to proceed.
+
+Set up SSH access
+~~~~~~~~~~~~~~~~~
+
+On the **SSH Setup** screen, enable **Install OpenSSH server**. Verify that **No**
+is selected for the **Import SSH Identity** option, as a custom SSH key will be created
+for the administration account later in the installation process. 
+
+Verify that **Allow password authentication over SSH** is selected, and choose **Done**
+to proceed.
+
+Finish the installation
 ~~~~~~~~~~~~~~~~~~~~~~~
+On the **Featured server snaps** screen, ensure that no snaps are selected and
+choose **Done** to start the server installation process.
 
-Wait for the base system to finish installing. When you get to the
-*Configure tasksel* screen, choose **No automatic updates**. The
-subsequent SecureDrop installation will include a task that handles
-regular software updates.
-
-.. note:: The Ansible playbooks for SecureDrop will configure automatic
-          updates via ``unattended-upgrades``. As part of the automatic update
-          process, the servers will reboot nightly. See the
-          :ref:`OSSEC guide <AnalyzingAlerts>` for example notifications
-          generated by the reboots.
-
-When you get to the software selection screen, deselect the preselected
-**Standard system utilities** and select **OpenSSH server** by highlighting each
-option and pressing the space bar.
-
-.. caution:: Hitting enter before the space bar will force you to start the
-             installation process over.
-
-Once **OpenSSH Server** is selected, hit *Continue*.
-
-You will then have to wait for the packages to finish installing.
-
-When the packages are finished installing, Ubuntu will automatically
-install the bootloader (GRUB). If it asks to install the bootloader to
-the Master Boot Record, choose **Yes**. When everything is done, reboot.
-
-.. note:: If you're installing Ubuntu on a NUC8 using a USB Ethernet adaptor,
-  you should now complete the steps listed in :ref:`nuc8_enable_network` before
-  proceeding with the rest of the installaton.
-
-.. |Ubuntu Server| image:: images/install/ubuntu_server.png
+Once the server installation is complete, choose **Reboot Now** to reboot the system.
 
 .. _nuc8_back_to_setup:
 
@@ -352,9 +315,9 @@ Set Up SSH Keys
 Ubuntu's default SSH configuration authenticates users with their
 passphrases; however, public key authentication is more secure, and once
 it's set up it is also easier to use. In this section, we will create
-a new SSH key for authenticating to both servers. Since the Admin Live
-USB was set up with `SSH Client Persistence`_, this key will be saved
-on the Admin Live USB and can be used in the future to authenticate to
+a new SSH key for authenticating to both servers. Since the *Admin
+Workstation* was set up with `SSH Client Persistence`_, this key will be saved
+on the *Admin Workstation* and can be used in the future to authenticate to
 the servers in order to perform administrative tasks.
 
 .. _SSH Client Persistence: https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html#index3h2

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -1,12 +1,38 @@
 Set Up the Servers
 ==================
 
+Pre-Install Steps
+-----------------
+
+Upgrade the Server BIOS
+~~~~~~~~~~~~~~~~~~~~~~~
+Before beginning the installation process, you should upgrade your servers' BIOS
+to the most recent stable version available. This process will differ for each
+server make/model - if you are using one of the recommended NUC models, you can
+find instructions in :doc:`update_bios`.
+
+Update BIOS Settings
+~~~~~~~~~~~~~~~~~~~~
+Once the BIOS has been updated, you should boot into it again to disable any unused
+hardware, including:
+
+* wireless LAN and Bluetooth
+* Thunderbolt support
+* audio support (output, speakers, microphones)
+* other features supported by the hardware but not used by SecureDrop.
+
+In most cases, you should enable support for LAN and USB ports only.
+
+You should also check the servers' boot settings. Ubuntu 20.04 supports both
+Legacy and UEFI boot modes, with UEFI preferred. You should also disable Secure
+Boot. SecureDrop uses a custom kernel with security patches, which is unsigned
+and will not boot if Secure Boot is enabled.
 
 Install Ubuntu
 --------------
 
 .. note:: Installing Ubuntu is simple and may even be something you are very familiar
-  with, but it is **strongly** encouraged that youread and follow this documentation
+  with, but it is **strongly** encouraged that you read and follow this documentation
   exactly as there are some "gotchas" that may cause your SecureDrop setup to break.
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server

--- a/docs/update_bios.rst
+++ b/docs/update_bios.rst
@@ -18,7 +18,7 @@ What you need
 Perform Backups
 ~~~~~~~~~~~~~~~
 
-Before performing any updates on the servers, we recommend you :doc:`back up the Application Server <backup_and_restore>`.
+If you are updating the BIOS on an existing SecureDrop system, we recommend you :doc:`back up the Application Server <backup_and_restore>` before proceeding.
 
 Prepare the USB Stick
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Status


Ready for review


## Description of Changes

- Updates server OS install instructions to use Ubuntu 20.04 LTS
- Removes workarounds for NUC8 Ethernet support, as they're not required with Focal's base kernel.

## Testing
- Are the docs clear and correct?
- Following them, do you get a valid SD install?

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed **not tested**
- [x] You have previewed (`make docs`) docs at http://localhost:8000