### PR TITLE
Add deletion docs to Journalist Guide

### DIFF
--- a/docs/images/manual/screenshots/journalist-delete_source_account.png
+++ b/docs/images/manual/screenshots/journalist-delete_source_account.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8dd91d867a9886050dd986516d3eeff8131697623cb92551132fbbc2b7ab119
+size 127752

--- a/docs/images/manual/screenshots/journalist-delete_sources.png
+++ b/docs/images/manual/screenshots/journalist-delete_sources.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba2d7804848b24ccbf27f758f13f9dbaa10239919b9c44d503c6e60518f3ffc4
+size 117988

--- a/docs/images/manual/screenshots/journalist-delete_submissions.png
+++ b/docs/images/manual/screenshots/journalist-delete_submissions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f409603a5ccb0f1c16c70b331b8ea1d7f289bbf1264341b1b29d0d1418bb4dc6
+size 86851

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -645,6 +645,57 @@ audio, and begin publishing important, high-impact work!
          <getting_the_most_out_of_securedrop>` to read about
          encouraging sources to use SecureDrop.
 
+Deleting submissions and source accounts
+----------------------------------------
+
+As part of routine SecureDrop usage, we recommend that you establish data retention
+practices consistent with your organization's threat model, data lifecycle and data
+retention policies. Regularly deleting submissions and source accounts can
+mitigate risks in the event that your SecureDrop servers or a source's account
+details are compromised.
+
+To delete sources, first select them in the list of all sources in the
+*Journalist Interface*, then click the **Delete** button. You will be
+given a choice to delete all messages and files for the selected sources, or to
+delete the source accounts:
+
+|Delete sources|
+
+If you delete messages and files for a source, the source will continue to appear
+in the list of sources in the *Journalist Interface*, and they will still be able
+to log into the *Source Interface* using their codename. Consider using this
+option as part of regular deletion of reviewed submissions, especially if you
+are not sure that all communication with the source has concluded.
+
+.. note::
+
+   If you delete all messages and files, that includes all replies you have sent
+   to the source, even if the source has not seen them yet. You will still be
+   able to send new replies.
+
+If you delete the entire source account, the source will not be able to log
+in again using their codename, and all information about them will be
+destroyed. Consider using this option if it is clear that all communication
+with the source has concluded, or if the source has requested that all information
+about them and their submissions should be removed.
+
+You can more selectively delete source submissions and journalist replies by
+clicking the source's two-word designation in the list of all sources. You will
+see a list of source messages (filenames end with ``-msg.gpg``), file submissions
+(filenames end with ``-doc.gz.gpg``) and journalist replies (filenames end with
+``--reply.gpg``).
+
+Select the source data you wish to delete, then click the **Delete** button.
+You will be prompted for confirmation:
+
+|Delete individual submissions|
+
+From the same page, you also have the option to delete the entire source
+account. To do so, click the button labeled **Delete Source Account** at the
+bottom of the page. You will be prompted for confirmation:
+
+|Delete source account|
+
 .. |Journalist Interface Login| image:: images/manual/screenshots/journalist-index_with_text.png
 .. |Journalist Interface| image:: images/manual/screenshots/journalist-index_javascript.png
 .. |Load external content| image:: images/manual/screenshots/journalist-clicks_on_source_and_selects_documents.png
@@ -660,6 +711,9 @@ audio, and begin publishing important, high-impact work!
 .. |Sent reply| image:: images/manual/screenshots/journalist-composes_reply.png
 .. |Flag for reply button| image:: images/manual/screenshots/journalist-col_has_no_key.png
 .. |Flag for reply notification| image:: images/manual/screenshots/journalist-col_flagged.png
+.. |Delete sources| image:: images/manual/screenshots/journalist-delete_sources.png
+.. |Delete individual submissions| image:: images/manual/screenshots/journalist-delete_submissions.png
+.. |Delete source account| image:: images/manual/screenshots/journalist-delete_source_account.png
 
 .. |mat2 context menu| image:: images/manual/screenshots/mat2_context_menu.png
 .. |mat2 cleaned| image:: images/manual/screenshots/mat2_cleaned.png


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds basic information about deletion, including the new options afforded by https://github.com/freedomofpress/securedrop/pull/5770, to the journalist guide.

Resolves #155

## Testing

Visual review should be sufficient for a reviewer already familiar with the changes in https://github.com/freedomofpress/securedrop/pull/5770

## Release 

Expected to be released with SecureDrop 1.8.0.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000