### PR TITLE
Update server time synchronization instructions

### DIFF
--- a/docs/test_the_installation.rst
+++ b/docs/test_the_installation.rst
@@ -72,11 +72,11 @@ Test the Web Interfaces
 
    - Open the *Journalist Interface* in Tor Browser by clicking on its desktop
      shortcut.  Enter your passphrase and two-factor code to log in.
-   - If you have problems logging in to the *Admin/Journalist Interface*,
-     SSH to the *Application Server* and restart the ntp daemon to synchronize
-     the time: ``sudo service ntp restart``. Also check that your
-     smartphone's time is accurate and set to network time in its
-     device settings.
+   - If you have problems logging in to the *Admin/Journalist
+     Interface*, SSH to the *Application Server* and restart the time
+     synchronization daemon to synchronize the time: ``sudo systemctl
+     restart systemd-timesyncd``. Also check that your smartphone's
+     time is accurate and set to network time in its device settings.
 
 #. Test replying to the test submission.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

After we switch from `ntpd` to `systemd-timesyncd` on Focal (https://github.com/freedomofpress/securedrop/pull/5806), the command to restart the time synchronization daemon will change.

## Testing

- `git checkout -b update-time-sync-instructions origin/update-time-sync-instructions`
- `make docs` 
- Visit http://localhost:8000/test_the_installation.html#test-the-web-interfaces and proofread the change.
- Build a staging environment from the https://github.com/freedomofpress/securedrop/tree/remove-ntp branch, ssh into the app server and verify that the command works. Just kidding. That's overkill.

## Release 

This should be held until we release Focal support.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000