### PR TITLE
add disable secure boot instructions

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -413,16 +413,19 @@ to disable wireless functionality:
 
 |NUC8 VisualBios1|
 
-While in the BIOS, you should also navigate to **Advanced > Security** in the
-and disable SGX support, which not used by SecureDrop and may be targeted by
-active CPU exploits:
+- navigate to **Advanced > Security** in the BIOS and disable SGX support, which is not used by 
+  SecureDrop and may be targeted by active CPU exploits:
 
 |NUC8 VisualBios2|
+
+- navigate to **Advanced > Boot > Secure Boot** and uncheck the **Secure Boot** checkbox:
+
+|NUC8 VisualBIOS SecureBoot|
 
 .. |NUC8 leads| image:: images/hardware/nuc8_leads.jpg
 .. |NUC8 VisualBIOS1| image:: images/hardware/nuc8_visualbios1.png
 .. |NUC8 VisualBIOS2| image:: images/hardware/nuc8_visualbios2.png
-
+.. |NUC8 VisualBIOS SecureBoot| image:: images/hardware/nuc8_visualbios_secureboot.png
 
 .. _nuc8_enable_network:
 

--- a/docs/images/hardware/nuc8_visualbios_secureboot.png
+++ b/docs/images/hardware/nuc8_visualbios_secureboot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f843318aa92b06e7225c0b0ebbbe79ce885bc4f2da2df6f79bdb84e36016e4b
+size 76807


### PR DESCRIPTION
## Description

Add instructions to disable Secure Boot (until we make this so that it's no longer a requirement).

Can't remember if I had to do this for nuc7, but it might make sense to move the instructions to the top as a check for all nucs.

* Fixes https://github.com/freedomofpress/securedrop-docs/issues/151