### PR TITLE
Fix broken link and update permanent redirects

### DIFF
--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -4,7 +4,7 @@ Contributing Guidelines
 Signing commits
 ---------------
 
-Commits should be signed, as `explained in the GitHub documentation <https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/signing-commits>`_.
+Commits should be signed, as `explained in the GitHub documentation <https://docs.github.com/en/github/authenticating-to-github/signing-commits>`_.
 This helps verify commits proposed in a pull request are from the expected author.
 
 Branching Strategy

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -261,7 +261,7 @@ Release Process
 #. Push your commits to the remote ``release`` branch. This will trigger an
    automatic upload of the packages to ``apt-qa.freedom.press``, but the
    packages will not yet be installable.
-#. Create a `draft PR <https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests>`__
+#. Create a `draft PR <https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests>`__
    from ``release`` into ``main``. Make sure to include a link to the build
    logs in the PR description.
 #. A reviewer must verify the build logs, obtain and sign the generated ``Release``

--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -218,7 +218,7 @@ from the `Vagrant Downloads page`_ and then install it.
     # OR this, if you downloaded the deb package.
     sudo dpkg -i vagrant.deb
 
-.. _`Vagrant Downloads page`: https://www.vagrantup.com/downloads.html
+.. _`Vagrant Downloads page`: https://www.vagrantup.com/downloads
 .. _`GitHub #932`: https://github.com/freedomofpress/securedrop/pull/932
 .. _`GitHub #1381`: https://github.com/freedomofpress/securedrop/issues/1381
 
@@ -289,7 +289,7 @@ different version, the path to ``virtualenvwrapper.sh`` will differ. Running
 
 The version of rsync installed by default on macOS is extremely out-of-date, as is Apple's custom. We recommend using Homebrew_ to install a modern version (3.1.0 or greater): ``brew install rsync``.
 
-.. _Vagrant: https://www.vagrantup.com/downloads.html
+.. _Vagrant: https://www.vagrantup.com/downloads
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads
 .. _Ansible: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
 .. _Homebrew: https://brew.sh/

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -680,7 +680,7 @@ Network Firewall
 ^^^^^^^^^^^^^^^^
 
 We recommend the `pfSense SG-3100
-<https://store.netgate.com/SG-3100.aspx>`__. It has 3 NICs and an internal
+<https://shop.netgate.com/products/3100-base-pfsense>`__. It has 3 NICs and an internal
 switch, increasing the number of available ports to 6.
 
 Network Switch

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -617,7 +617,7 @@ Decrypting and Preparing to Publish
    To decrypt a VeraCrypt drive on a Windows or Mac workstation, you need
    to have the VeraCrypt software installed. If you are unsure if you have the
    software installed or how to use it, ask your administrator, or see
-   the `Freedom of the Press Foundation guide <https://freedom.press/training/encryption-toolkit-media-makers-veracrypt-guide/>`__
+   the `Freedom of the Press Foundation guide <https://freedom.press/training/encryption-toolkit-media-makers/encryption-toolkit-media-makers-veracrypt-guide/>`__
    for working with VeraCrypt.
 
 To access the *Export Device* on your everyday workstation, follow these steps:

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -18,7 +18,7 @@ pfSense pre-installed, such as the one recommended in the
 :ref:`Hardware Guide <hardware_guide>`.
 
 We currently recommend the `pfSense SG-3100
-<https://store.netgate.com/SG-3100.aspx>`__, which has 3 network interfaces
+<https://shop.netgate.com/products/3100-base-pfsense>`__, which has 3 network interfaces
 and 6 ports: WAN, OPT1, LAN1, LAN2, LAN3 and LAN4. This firewall comes with
 an internal switch on the LAN interface. If yours does not you will need to
 obtain a separate switch to connect the *Admin Workstation* for the initial


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->
Ready for review

## Description of Changes

Fixes a broken link (to a FPF guide which URL has changed) and update 6 other that are now permanently redirected.
This clears all the "red" warnings in the `make linkcheck` output and **fixes the [nightly build](https://circleci.com/gh/freedomofpress/securedrop-docs/351?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)**.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->

- [ ] Check that the links point to the expected pages

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
_No special considerations for release._


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed [1]
- [x] You have previewed (`make docs`) docs at http://localhost:8000

[1] Locally `make docs-linkcheck` hangs just after checking the link to Ubuntu releases in the `servers` page. I'm not quite sure why yet, but it seems unrelated to the content of this PR. The page after that is `setup_admin_tails` and it renders all right locally.