### PR TITLE
Fix (updated) link to FPF guide

### DIFF
--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -617,7 +617,7 @@ Decrypting and Preparing to Publish
    To decrypt a VeraCrypt drive on a Windows or Mac workstation, you need
    to have the VeraCrypt software installed. If you are unsure if you have the
    software installed or how to use it, ask your administrator, or see
-   the `Freedom of the Press Foundation guide <https://freedom.press/training/encryption-toolkit-media-makers/encryption-toolkit-media-makers-veracrypt-guide/>`__
+   the `Freedom of the Press Foundation guide <https://freedom.press/training/encryption-toolkit-media-makers/veracrypt-guide/>`__
    for working with VeraCrypt.
 
 To access the *Export Device* on your everyday workstation, follow these steps:


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

The [reorganization of the FPF guides][ref] resulted in a shorter (and nicer IMHO) link. This PR follows up on the previous update #163 to so that the nightly link check becomes green again.

  [ref]: https://github.com/freedomofpress/securedrop-docs/pull/163#pullrequestreview-604414166

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] Check the link opens the FPF guide on VeraCrypt

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
_No special considerations for release._

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed (**note**: the relevant check is ok.)
- [x] You have previewed (`make docs`) docs at http://localhost:8000