### PR TITLE
Remove logo backup instructions

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -104,24 +104,6 @@ archive in the output of the backup command.
 
 .. include:: includes/backup-warning.txt
 
-.. _backing_up_logos:
-
-Backing up your custom logo
-'''''''''''''''''''''''''''
-
-The backup will not include any custom logo file that you have configured
-for your SecureDrop instance. To back up your logo:
-
-1. Open a terminal via **Applications ▸ System Tools ▸ Terminal**.
-2. Change into the persistent storage directory: ``cd ~/Persistent``
-3. Run the following command:
-
-.. code:: sh
-
-  wget $(grep Exec ~/source.desktop | awk '{print $2}')/org-logo -O logo-backup.png
-
-This will save your current logo file as ``logo-backup.png``.
-
 Restoring from a Backup
 -----------------------
 
@@ -356,9 +338,6 @@ Migrating Using a V2+V3 or V3-Only Backup
 #. :doc:`Test the new instance <test_the_installation>` to verify that the
    web interfaces are available and the servers can be reached via SSH.
 
-#. If you had previously configured a custom logo for your SecureDrop instance,
-   :ref:`upload it again <Updating Logo Image>` using the *Admin Interface*.
-
 #. If you have migrated to new hardware, ensure your old servers have been
    decommissioned and/or destroyed by following the relevant sections of
    :doc:`our decommissioning documentation <decommission>`.
@@ -577,9 +556,6 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 #. As part of this process, your .onion URLs have changed, and *Journalist* and
    *Admin Workstations* will be out of date, and will need to be
    :ref:`updated <update_tails_v3>`.
-
-#. If you had previously configured a custom logo for your SecureDrop instance,
-   :ref:`upload it again <Updating Logo Image>` using the *Admin Interface*.
 
 #. If you have migrated to new hardware, ensure your old servers have been
    decommissioned and/or destroyed by following the relevant sections of

--- a/docs/upgrade/focal_migration.rst
+++ b/docs/upgrade/focal_migration.rst
@@ -210,8 +210,6 @@ you have completed the :ref:`preparatory steps <focal_prep>`.
 #. Announce your maintenance window. As part of this procedure, your servers
    will become unreachable.
 #. :doc:`Take a backup of the current instance <../backup_and_restore>`.
-   If you have configured a custom logo for your SecureDrop instance, make
-   sure to :ref:`download it <backing_up_logos>` as well.
 
    Once you have taken a backup of the servers, power them off.
 


### PR DESCRIPTION
No longer needed once fix for backup script (https://github.com/freedomofpress/securedrop/pull/5880) is included in a release.

## Status
Ready for review

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000