### PR TITLE
Point to centralized Code of Conduct instead of local copy

### DIFF
--- a/docs/development/client.rst
+++ b/docs/development/client.rst
@@ -102,8 +102,8 @@ Contributing
 
 Our open issues are `on GitHub <https://github.com/freedomofpress/securedrop-client/issues>`_.
 
-Please remember that we have a code of conduct and expect all contributors to
-abide by it.
+Please remember that we have a `Code of Conduct <https://github.com/freedomofpress/.github/blob/main/CODE_OF_CONDUCT.md>`__
+and expect all contributors to abide by it.
 
 Before submitting a pull request, make sure the test suite passes
 (``make check``), because our CI tools will flag broken tests before we're able

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -24,7 +24,7 @@ participate in longer discussions.
 
    The SecureDrop GitHub repositories and other project resources are managed
    by `Freedom of the Press Foundation employees <https://freedom.press/about/staff>`__.
-   All SecureDrop contributors are required to abide by the project's `Code of Conduct <https://github.com/freedomofpress/securedrop/blob/develop/CODE_OF_CONDUCT.md>`__.
+   All SecureDrop contributors are required to abide by the project's `Code of Conduct <https://github.com/freedomofpress/.github/blob/main/CODE_OF_CONDUCT.md>`__.
 
 
 * To start contributing to the `codebase <https://github.com/freedomofpress>`__, see our :doc:`contributing guidelines <contributor_guidelines>`.


### PR DESCRIPTION
## Status
Ready for review
## Description
Part of efforts to centralize Code of Conduct management for FPF open source repos. See:
- https://github.com/freedomofpress/.github/pull/1
- https://github.com/freedomofpress/securedrop/pull/5889

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000