### PR TITLE
Improve integration of images with surounding text using the figure element

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -216,7 +216,11 @@ passphrase, and two-factor authentication token to log in.
 
 By default, you will be logged in to the *Journalist Interface*'s source list page.
 
-|SecureDrop main page|
+.. figure:: images/manual/screenshots/journalist-admin_index_no_documents.png
+   :align: center
+   :alt: The top navigation of the Journalist Interface says 'Logged on as Journalist' and displays an 'Admin' link.
+   :figwidth: 80%
+   :width: 100%
 
 In the course of normal administration operations you should not need to view source
 communications, but if you do, you can find information on managing submissions in
@@ -254,11 +258,19 @@ account setup.
 
 #. Click **Admin** in the top right corner of the page to load the *Admin Interface*.
 
-   |SecureDrop admin home|
+   .. figure:: images/manual/screenshots/journalist-admin_interface_index.png
+      :align: center
+      :alt: The Admin Interface displays an 'Add User' button.
+      :figwidth: 80%
+      :width: 100%
 
 #. Click **Add User** to add a new user.
 
-   |Add a new user|
+   .. figure:: images/manual/screenshots/journalist-admin_add_user_totp.png
+      :align: center
+      :alt: The form used to create new users displays a pre-generated Diceware passphrase.
+      :figwidth: 80%
+      :width: 100%
 
 #. Hand the keyboard over to the journalist so they can create their own username.
 #. Once they’re done entering a username for themselves, have them save their pre-generated Diceware passphrase to their password manager.
@@ -275,7 +287,13 @@ FreeOTP
 
 #. If the journalist is using FreeOTP or another app for two-factor authentication, click **Add User** to proceed to the next page.
 
-   |Enable FreeOTP|
+   .. figure:: images/manual/screenshots/journalist-admin_new_user_two_factor_totp.png
+      :align: center
+      :alt: The form used to enable FreeOTP displays a barcode and a two-factor secret.
+      :figwidth: 80%
+      :width: 100%
+
+      Click on the image to see it full-size.
 
 #. Next, the journalist should open FreeOTP on their smartphone and scan the barcode displayed on the screen.
 #. If they have difficulty scanning the barcode, they can tap on the icon at the top that shows a plus and the symbol of a key and use their phone's keyboard to input the two-factor secret into the ``Secret`` input field, without whitespace.
@@ -290,11 +308,21 @@ YubiKey
 
 #. If the journalist wishes to use a YubiKey for two-factor authentication, select **Is using a YubiKey**. You will then need to enter their YubiKey's OATH-HOTP Secret Key. For more information on how to retrieve this key, read the :doc:`YubiKey Setup Guide <yubikey_setup>`.
 
-   |Enable YubiKey|
+   .. figure:: images/manual/screenshots/journalist-admin_add_user_hotp.png
+      :align: center
+      :alt: The form used to create new users, filled with the 40-character HOTP secret key of a Yubikey.
+      :figwidth: 80%
+      :width: 100%
+
+      User account creation screen with YubiKey OATH-HOTP Secret Key, as seen by an admin. Click on the image to see it full-size.
 
 #. Once you've entered the Yubikey's OATH-HOTP Secret Key, click **Add User**.  On the next page, have the journalist authenticate using their YubiKey, by inserting it into a USB port on the workstation and pressing its button.
 
-   |Verify YubiKey|
+   .. figure:: images/manual/screenshots/journalist-admin_new_user_two_factor_hotp.png
+      :align: center
+      :alt: The form used to verify the setup of the Yubikey requests a 6-digit verification code.
+      :figwidth: 80%
+      :width: 100%
 
 #. If everything was set up correctly, you will be redirected back to the *Admin Interface*, where you should see a flashed message that says "The two-factor code for user *new username* was verified successfully.".
 
@@ -323,7 +351,13 @@ can reset their account as follows:
 #. Select *Admin* at the top right to open the *Admin Interface*
 #. Find the user's account name and select **Edit**
 
-|Reset Passphrase|
+   .. figure:: images/manual/screenshots/journalist-edit_account_user.png
+      :align: center
+      :alt: The account edition form allows to change name, reset password, and reset two-factor authentication.
+      :figwidth: 80%
+      :width: 100%
+
+      Click on the image to see it full-size.
 
 Next, you can either rotate their passphrase or reset two-factor authentication
 for their account.
@@ -342,7 +376,6 @@ To reset two-factor authentication:
      * Click **Reset Security Key Credentials** for accounts using a Yubikey
 
   #. Follow the on-screen instructions to complete the process and verify their new two-factor authentication credentials.
-
 
 Off-boarding Users
 ^^^^^^^^^^^^^^^^^^
@@ -380,7 +413,13 @@ PNG-format images are supported. To update the logo image:
 
 You should see a message appear indicating the change was a success.
 
-|Logo Update|
+.. figure:: images/manual/screenshots/journalist-admin_changes_logo_image.png
+   :align: center
+   :alt: The Instance Configuration form displays 'Image updated' after the logo was updated successfully.
+   :figwidth: 80%
+   :width: 100%
+
+   Click on the image to see it full-size.
 
 .. _submission prefs:
 
@@ -404,7 +443,13 @@ Testing OSSEC Alerts
 To verify that the OSSEC monitoring system's functionality, you can send a test
 OSSEC alert by clicking **Send Test OSSEC Alert**.
 
-|Test Alert|
+.. figure:: images/manual/screenshots/journalist-admin_ossec_alert_button.png
+   :align: center
+   :alt: The Instance Configuration form displays 'Test alert sent' after a test OSSEC alert was sent successfully.
+   :figwidth: 80%
+   :width: 100%
+
+   Click on the image to see it full-size.
 
 You should receive an OSSEC alert email at the address specified during the
 installation of SecureDrop. The email may take several minutes to arrive. If
@@ -798,22 +843,3 @@ impact of re-rerunning ``./securedrop-admin install`` more than once. The
 command will simply check which tasks have been completed, and pick up where it
 left off. However, if the same issue persists, you will need to investigate
 further.
-
-.. |Reset Passphrase| image:: images/manual/screenshots/journalist-edit_account_user.png
-   :alt: The account editing form allows admins to change name, reset passphrase, and reset two-factor authentication.
-.. |Test Alert| image:: images/manual/screenshots/journalist-admin_ossec_alert_button.png
-   :alt: The Instance Configuration form displays 'Test alert sent' after a test OSSEC alert was sent successfully.
-.. |SecureDrop main page| image:: images/manual/screenshots/journalist-admin_index_no_documents.png
-   :alt: The top navigation of the Journalist Interface says 'Logged on as Journalist' and displays an 'Admin' link.
-.. |SecureDrop admin home| image:: images/manual/screenshots/journalist-admin_interface_index.png
-   :alt: The Admin Interface displays an 'Add User' button.
-.. |Add a new user| image:: images/manual/screenshots/journalist-admin_add_user_totp.png
-   :alt: The form used to create new users displays a pre-generated Diceware passphrase.
-.. |Enable FreeOTP| image:: images/manual/screenshots/journalist-admin_new_user_two_factor_totp.png
-   :alt: The form used to enable FreeOTP displays a barcode and a two-factor secret.
-.. |Enable YubiKey| image:: images/manual/screenshots/journalist-admin_add_user_hotp.png
-   :alt: The form used to create new users, filled with the 40-character HOTP secret key of a Yubikey.
-.. |Verify YubiKey| image:: images/manual/screenshots/journalist-admin_new_user_two_factor_hotp.png
-   :alt: The form used to verify the setup of the Yubikey requests a 6-digit verification code.
-.. |Logo Update| image:: images/manual/screenshots/journalist-admin_changes_logo_image.png
-   :alt: The Instance Configuration form displays 'Image updated' after the logo was updated successfully.

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -293,8 +293,6 @@ FreeOTP
       :figwidth: 80%
       :width: 100%
 
-      Click on the image to see it full-size.
-
 #. Next, the journalist should open FreeOTP on their smartphone and scan the barcode displayed on the screen.
 #. If they have difficulty scanning the barcode, they can tap on the icon at the top that shows a plus and the symbol of a key and use their phone's keyboard to input the two-factor secret into the ``Secret`` input field, without whitespace.
 #. Inside the FreeOTP app, a new entry for this account will appear on the main screen, with a six-digit number that recycles to a new number every thirty seconds.  The journalist should enter the six-digit number in the  **Verification code** field at the bottom of the **Enable FreeOTP** form and click **Submit**.
@@ -314,8 +312,7 @@ YubiKey
       :figwidth: 80%
       :width: 100%
 
-      User account creation screen with YubiKey OATH-HOTP Secret Key, as seen by an admin. Click on the image to see it full-size.
-
+      User account creation screen with YubiKey OATH-HOTP Secret Key, as seen by an admin.
 #. Once you've entered the YubiKey's OATH-HOTP Secret Key, click **Add User**.  On the next page, have the journalist authenticate using their YubiKey, by inserting it into a USB port on the workstation and pressing its button.
 
    .. figure:: images/manual/screenshots/journalist-admin_new_user_two_factor_hotp.png
@@ -356,8 +353,6 @@ can reset their account as follows:
       :alt: The account edition form allows to change name, reset password, and reset two-factor authentication.
       :figwidth: 80%
       :width: 100%
-
-      Click on the image to see it full-size.
 
 Next, you can either rotate their passphrase or reset two-factor authentication
 for their account.
@@ -419,8 +414,6 @@ You should see a message appear indicating the change was a success.
    :figwidth: 80%
    :width: 100%
 
-   Click on the image to see it full-size.
-
 .. _submission prefs:
 
 Setting Submission Preferences
@@ -448,8 +441,6 @@ OSSEC alert by clicking **Send Test OSSEC Alert**.
    :alt: The Instance Configuration form displays 'Test alert sent' after a test OSSEC alert was sent successfully.
    :figwidth: 80%
    :width: 100%
-
-   Click on the image to see it full-size.
 
 You should receive an OSSEC alert email at the address specified during the
 installation of SecureDrop. The email may take several minutes to arrive. If

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -250,7 +250,7 @@ After logging in, you can add new user accounts for the journalists at your orga
 who will be checking the system for submissions. Make sure the journalist is
 physically in the same room as you when you do this, as they will have to be present
 to enable two-factor authentication. SecureDrop supports the use of either a
-smartphone authenticator app or a Yubikey for two-factor authentication. If an
+smartphone authenticator app or a YubiKey for two-factor authentication. If an
 app is to be used, the journalist should install it before proceeding with the
 account setup.
 
@@ -310,17 +310,17 @@ YubiKey
 
    .. figure:: images/manual/screenshots/journalist-admin_add_user_hotp.png
       :align: center
-      :alt: The form used to create new users, filled with the 40-character HOTP secret key of a Yubikey.
+      :alt: The form used to create new users, filled with the 40-character HOTP secret key of a YubiKey.
       :figwidth: 80%
       :width: 100%
 
       User account creation screen with YubiKey OATH-HOTP Secret Key, as seen by an admin. Click on the image to see it full-size.
 
-#. Once you've entered the Yubikey's OATH-HOTP Secret Key, click **Add User**.  On the next page, have the journalist authenticate using their YubiKey, by inserting it into a USB port on the workstation and pressing its button.
+#. Once you've entered the YubiKey's OATH-HOTP Secret Key, click **Add User**.  On the next page, have the journalist authenticate using their YubiKey, by inserting it into a USB port on the workstation and pressing its button.
 
    .. figure:: images/manual/screenshots/journalist-admin_new_user_two_factor_hotp.png
       :align: center
-      :alt: The form used to verify the setup of the Yubikey requests a 6-digit verification code.
+      :alt: The form used to verify the setup of the YubiKey requests a 6-digit verification code.
       :figwidth: 80%
       :width: 100%
 
@@ -373,7 +373,7 @@ To reset two-factor authentication:
   #. Click the button that corresponds to the user's chosen two-factor authentication method:
 
      * Click **Reset Mobile App Credentials** for accounts using FreeOTP or a similar authentication app
-     * Click **Reset Security Key Credentials** for accounts using a Yubikey
+     * Click **Reset Security Key Credentials** for accounts using a YubiKey
 
   #. Follow the on-screen instructions to complete the process and verify their new two-factor authentication credentials.
 
@@ -759,8 +759,8 @@ revert the server configuration to an older version.
 
 The simplest approach to keeping workstations in sync is to inform other admins
 of changes as you make them, for example via a secure Signal group chat. Any such
-communications should happen over a platform that provides E2EE, as you may need to
-share sensitive information.
+communications should happen over a platform that provides end-to-end encryption,
+as you may need to share sensitive information.
 
 Configuration information is stored in several files on the *Admin Workstation* under
 ``~/Persistent/securedrop/``:


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Work in progress

## Description of Changes

Adds captions to all images in the documentation by using the [`figure`][fig] directive. Each caption describes the image and hints that clicking on the image will display it in full size. Since the possibility of opening the image in full size is now explicit, this PR aslo slightly reduces the size of the images in the docs in order to reduce the interruption that illustrations cause to the flow of the text.

  [fig]: https://docutils.sourceforge.io/docs/ref/rst/directives.html#figure

This is a follow up on the introduction of image captions in #141.

### Pros

- Image descriptions make content more accessible.
- Images don't interrupt the text flow as much.
- It is clear that images can be opened full-size.

### Accepted trade-offs

- Unlike the `image` directive, `figure` cannot be used in [`substitution definitions`][subst], which means that the image URLs cannot be grouped at the end of the document anymore. Because most images are used only once per document, I think that's an acceptable trade-off for the accessibility improvement.

  [subst]: https://docutils.sourceforge.io/docs/ref/rst/directives.html#directives-for-substitution-definitions

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
_I'll update when the PR is ready for review._

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
_No special considerations before release come to mind yet, I'll confirm when the PR is ready for review._

## Example

![image](https://user-images.githubusercontent.com/1619067/114287227-af3b1480-9aa8-11eb-992e-d2772a6ba904.png)

Note: the pixellation on the image is due to the amount of zoom out I applied to keep the screenshot size small. The figures don't appear pixellated in the docs ([example](https://docs.securedrop.org/en/latest/development/translations.html)).

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000