### PR TITLE
Adds details about OSSEC rule addition

### DIFF
--- a/docs/development/updating_ossec.rst
+++ b/docs/development/updating_ossec.rst
@@ -113,7 +113,7 @@ to :ref:`defining a new rule <the_rules>` unless you have a reason to add additi
 The decoder file
 -----------------
 
-For example, to add a decoder for log events from ``fwupd``, we can add to
+For example, to add a decoder for log events from ``fwupd``, you can add to
 ``local_decoder.xml``:
 
 ::
@@ -125,7 +125,7 @@ For example, to add a decoder for log events from ``fwupd``, we can add to
       <program_name>fwupd</program_name>
     </decoder>
 
-We can find this ``program_name`` value using the :ref:`"ossec-logtest" command
+You can find this ``program_name`` value using the :ref:`"ossec-logtest" command
 <using_ossec_logtest>`.  Copy-paste the log event as input to this command, and
 it will give you some parsed output:
 
@@ -153,9 +153,9 @@ it will give you some parsed output:
 The rules
 ---------
 
-We decided to use the above mentioned `decoder` along with a group of rules.
-Here, we are making sure that the rules have proper unique `id` number, and
-they are written in the correct (sorted) place in the rules XML file.
+Next, you can add one or more rules corresponding to the new decoder, making
+sure that the rules have proper unique `id` numbers and are written in the
+correct (sorted) place in the ``local_rules.xml`` file.
 
 
 ::
@@ -187,7 +187,7 @@ the new rule:
     /var/ossec/bin/ossec-analysisd -t
 
 ``ossec-analysisd`` will receive log messages and compare them to our rules,
-including the new rule we just added. Then it creates alerts when a log message
+including the new rule you just added. Then it creates alerts when a log message
 matches an applicable rule.
 
 

--- a/docs/development/updating_ossec.rst
+++ b/docs/development/updating_ossec.rst
@@ -23,6 +23,8 @@ suggesting a rule for it. Each additional alert that admins must read and/or
 respond to takes time. Alerts that are unimportant or otherwise require no action
 can lead to alert fatigue and thus to critical alerts being ignored.
 
+.. _using_ossec_logtest :
+
 Using ``ossec-logtest``
 -----------------------
 
@@ -109,6 +111,9 @@ to :ref:`defining a new rule <the_rules>` unless you have a reason to add additi
 The decoder file
 -----------------
 
+For example, to add a decoder for log events from ``fwupd``, we can add to
+``local_decoder.xml``:
+
 ::
 
     <!--
@@ -118,13 +123,14 @@ The decoder file
       <program_name>fwupd</program_name>
     </decoder>
 
-In the above example, we are creating a new `decoder` based on the
-`program_name` value. We can find this `program_name` value using the
-`/var/ossec/bin/ossec-logtest` command, you can paste the login as input to
-this, and it will give you some parsed output.
+We can find this ``program_name`` value using the :ref:`"ossec-logtest" command
+<using_ossec_logtest>`.  Copy-paste the log event as input to this command, and
+it will give you some parsed output:
 
 ::
 
+    $ echo "Mar  1 13:22:53 app fwupd[133921]: 13:22:53:0883 FuPluginUefi         Error opening directory â€œ/sys/firmware/efi/esrt/entriesâ€�: No such file or directory" | sudo /var/ossec/bin/ossec-logtest
+    [...]
     **Phase 1: Completed pre-decoding.
         full event: 'Mar  1 13:22:53 app fwupd[133921]: 13:22:53:0883 FuPluginUefi         Error opening directory â€œ/sys/firmware/efi/esrt/entriesâ€�: No such file or directory'
         hostname: 'app'

--- a/docs/development/updating_ossec.rst
+++ b/docs/development/updating_ossec.rst
@@ -86,11 +86,25 @@ a failing test which you then can make pass with a patch to the OSSEC rules:
 How to add a new OSSEC rule?
 =============================
 
-There are two main files involved in this.
+OSSEC processes events in two steps:
 
-- `install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml` the rules file
-- `install_files/securedrop-ossec-server/var/ossec/etc/local_decoder.xml` the decoder file
+1. `Decoders <https://ossec-documentation.readthedocs.io/en/latest/manual/lids/decoders.html>`_
+   parse and filter log events that meet certain criteria for subsequent processing.
+   SecureDrop's custom rules are defined in
+   ``install_files/securedrop-ossec-server/var/ossec/rules/local_rules.xml``.
 
+2. `Rules <https://ossec-documentation.readthedocs.io/en/latest/manual/lids/rules.html>`_
+   check decoded events against conditions and optionally yield alerts.
+   SecureDrop's custom rules are defined in
+   ``install_files/securedrop-ossec-server/var/ossec/etc/local_decoder.xml``.
+
+A basic decoder filters log events by ``program_name`` (e.g., ``fwupd``).
+If a decoder is already defined for the program of interest, you can go straight
+to :ref:`defining a new rule <the_rules>` unless you have a reason to add additional
+:ref:`decoders <the_decoder_file>` for further filtering.
+
+
+.. _the_decoder_file:
 
 The decoder file
 -----------------
@@ -125,7 +139,8 @@ this, and it will give you some parsed output.
         Level: '2'
         Description: 'Unknown problem somewhere in the system.'
     **Alert to be generated.
-    
+
+.. _the_rules:
 
 The rules
 ---------

--- a/docs/development/updating_ossec.rst
+++ b/docs/development/updating_ossec.rst
@@ -59,6 +59,8 @@ level, you can simply pass the event to ``ossec-logtest``:
 
 This is the utility we use in automated tests of OSSEC.
 
+.. _writing_automated_tests_for_ossec_rules :
+
 Writing Automated Tests for OSSEC Rules
 ---------------------------------------
 
@@ -174,24 +176,30 @@ they are written in the correct (sorted) place in the rules XML file.
     </group>
 
 
-Verify the configuration change
---------------------------------
+Verify the new OSSEC rule
+-------------------------
 
-On the monitor server you can use the following command as `root` to verify the changes.
+On the monitor server you can use the following command as `root` to verify
+the new rule:
 
 ::
 
     /var/ossec/bin/ossec-analysisd -t
 
+``ossec-analysisd`` will receive log messages and compare them to our rules,
+including the new rule we just added. Then it creates alerts when a log message
+matches an applicable rule.
+
 
 Adding an automated test for staging
 -------------------------------------
 
-You can then add a test for the `molecule/testinfra/mon/test_ossec_ruleset.py`
-file. Here the test loops over different log lines mentioned in
-`log_events_without_ossec_alerts` variable in
-`molecule/testinfra/vars/staging.yml`, and makes sure that the `rule_id` and
-`level` matches. 
+You can then add tests in the ``molecule/testinfra/mon/test_ossec_ruleset.py``
+file. Here the test loops over the entries in the
+``log_events_with_ossec_alerts`` and ``log_events_without_ossec_alerts``
+variables in ``molecule/testinfra/vars/staging.yml`` and makes sure that the
+``rule_id`` and ``level`` match.  See :ref:`writing_automated_tests_for_ossec_rules`
+for details.
 
 
 


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

Adds steps for adding new OSSEC rules. This is focused on the developers.


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->

This is based on the wiki page at https://github.com/freedomofpress/securedrop/wiki/How-to-add-new-ossec-rules%3F

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->



## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000

### After merge
- [ ] Remove <https://github.com/freedomofpress/securedrop/wiki/How-to-add-new-ossec-rules%3F>