### PR TITLE
Remove keys from ssh-agent before regenerating them

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -203,10 +203,11 @@ Migrating Using a V2+V3 or V3-Only Backup
       mv ~/Persistent/securedrop ~/Persistent/sd.bak
 
 #. Move the existing *Admin Workstation* SSH configuration out of the way via
-   the Terminal, using the command:
+   the Terminal, using the commands:
 
    .. code:: sh
 
+      ssh-add -D
       find ~/.ssh/ -type f -exec mv {} {}.bak \;
 
    .. note::
@@ -391,6 +392,7 @@ process.
 
    .. code:: sh
 
+       ssh-add -D
        find ~/.ssh/ -type f -exec mv {} {}.bak \;
 
 #. From the LUKS-encrypted USB, copy ``~/.ssh/id_rsa`` and
@@ -454,6 +456,7 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
    .. code:: sh
 
+       ssh-add -D
        find ~/.ssh/ -type f -exec mv {} {}.bak \;
 
 #. Reinstall SecureDrop on the *Admin Workstation* using the following Terminal


### PR DESCRIPTION


## Status
Ready for review 

## Description of Changes
Adds instructions to run `ssh-add -D` to remove old ssh keys from `ssh-agent` before moving them out of the way as part of the restore process.

## Testing
- [ ] the instructions are clear and correct.

## Release 
Should be promoted ASAP as it improves Focal migrations steps

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000