### PR TITLE
Removes references to v2 services

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -680,17 +680,6 @@ Configuration information is stored in several files on the *Admin Workstation* 
   should be updated on other *Admin Workstations*.
 * Onion service information is stored in several files:
 
-  * v2 onion services:
-
-    .. code-block:: none
-
-      install_files/ansible-base/app-ssh-aths
-      install_files/ansible-base/mon-ssh-aths
-      install_files/ansible-base/app-journalist-aths
-      install_files/ansible-base/app-source-ths
-
-  * v3 onion services:
-
     .. code-block:: none
 
       install_files/ansible-base/app-ssh.auth_private
@@ -735,19 +724,7 @@ into your Admin Workstation, you should first perform the following troubleshoot
 #. **Ensure that SSH aliases and onion service authentication are configured:**
 
    - First, ensure that the correct configuration files are present in
-     ``~/Persistent/securedrop/install_files/ansible-base``.
-
-     If v2 onion services
-     are configured, you should have 4 files:
-
-     - ``app-ssh-aths``
-     - ``mon-ssh-aths``
-     - ``app-journalist-aths``
-     - ``app-source-ths``
-
-
-     If v3 onion services are
-     enabled, you should have the following 5 files:
+     ``~/Persistent/securedrop/install_files/ansible-base``:
 
      - ``app-ssh.auth_private``
      - ``mon-ssh.auth_private``

--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -164,8 +164,8 @@ Moving a SecureDrop instance to new hardware involves:
   - Installing SecureDrop on new hardware;
   - Restoring the backup to the new instance and repairing credentials.
 
-All new SecureDrop instances must use v3 onion services only, so the final
-configuration will only include v3 onion services regardless of the backup state.
+SecureDrop now supports only v3 onion services, so the final configuration will
+only include v3 onion services regardless of the backup state.
 
 .. note:: If you need to restore from a backup from an instance configured to
    use SSH-over-LAN onto an SSH-over-Tor instance, you must either first update
@@ -303,18 +303,16 @@ Migrating Using a V2+V3 or V3-Only Backup
 
    .. note::
 
-      You may need to wait approximately 10-15 minutes after installing 
+      You may need to wait approximately 10-15 minutes after installing
       Ubuntu 20.04 for the servers to become reachable via SSH.
 
 #. Reinstall SecureDrop on the servers, following the :doc:`installation
    instructions <install>`. During the configuration stage
    (``./securedrop-admin sdconfig``), the values will be prepopulated based on
-   the old instance's configuration. Press **Enter** to accept each value,
-   except when you are asked if you want to enable v2 onion services: there,
-   ensure the answer is ``no``.
+   the old instance's configuration. Press **Enter** to accept each value.
 
-   Proceed through the installation by running 
-   ``./securedrop-admin install`` then ``./securedrop-admin tailsconfig``. 
+   Proceed through the installation by running
+   ``./securedrop-admin install`` then ``./securedrop-admin tailsconfig``.
    If SSH-over-Tor is configured, run
    ``ssh app uptime`` and ``ssh mon uptime``  in the Terminal to verify SSH
    connectivity.
@@ -425,8 +423,8 @@ process.
 Migrating Using a V2-Only Backup
 ''''''''''''''''''''''''''''''''
 
-V2 onion services are no longer supported for new SecureDrop installs, so
-*Source* and *Journalist Interface* addresses will change when you perform a
+V2 onion services are no longer supported by SecureDrop, so v2 *Source* and
+*Journalist Interface* addresses will be replaced by v3 addresses when you perform a
 migration using a v2-only backup. However, it is possible to migrate submissions,
 source accounts, and journalist accounts. To do so, follow the steps below:
 
@@ -538,19 +536,17 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 #. Reinstall SecureDrop on the servers, following the :doc:`installation
    instructions <../install>`. During the configuration stage
    (``./securedrop-admin sdconfig``), the values will be prepopulated based on
-   the old instance's configuration. Press **Enter** to accept each value,
-   except for the the v2 and v3 onion service options - type ``no`` for v2 and
-   ``yes`` for v3.
+   the old instance's configuration. Press **Enter** to accept each value.
 
-   .. note:: 
+   .. note::
 
       If your old instance served the *Source Interface* over HTTPS,
       you will need to set up your new instance using HTTP instead, and update
       it to use HTTPS after the initial migration. The web interface addresses
       change as part of the process, and so your certificate is no longer valid.
 
-   Proceed through the installation by running 
-   ``./securedrop-admin install`` then ``./securedrop-admin tailsconfig``. 
+   Proceed through the installation by running
+   ``./securedrop-admin install`` then ``./securedrop-admin tailsconfig``.
    If SSH-over-Tor is configured, run
    ``ssh app uptime`` and ``ssh mon uptime``  in the Terminal to verify SSH
    connectivity and add the new onion URLs to your ``known_hosts`` file.

--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -44,91 +44,23 @@ Upgrading or Adding Python Dependencies
 
 We use a `pip-compile <https://nvie.com/posts/better-package-management/>`_
 based workflow for adding Python dependencies. If you would like to add a Python
-dependency, instead of editing the ``securedrop/requirements/*.txt`` files
+dependency, instead of editing the ``securedrop/requirements/python3/*.txt`` files
 directly, please:
 
-  #. Edit the relevant ``*.in`` file in ``securedrop/requirements/``
+  #. Edit the relevant ``*.in`` file in ``securedrop/requirements/python3``
   #. Use the following shell script to generate
-     ``securedrop/requirements/*.txt`` files:
+     ``securedrop/requirements/python3/*.txt`` files:
 
      .. code:: sh
 
         make update-pip-requirements
 
-  #. Commit both the ``securedrop/requirements/*.in`` and
-     ``securedrop/requirements/*.txt`` files
+  #. Commit both the ``securedrop/requirements/python3/*.in`` and
+     ``securedrop/requirements/python3/*.txt`` files
 
-.. _ssh_over_tor:
-
-Connecting to VMs via SSH Over Tor
-----------------------------------
-
-Ubuntu/Debian Setup
-~~~~~~~~~~~~~~~~~~~
-You will need to install a specific variant of the ``nc`` tool
-in order to support the ``-x`` option for specifying a proxy host.
-macOS already runs the OpenBSD variant by default.
-
-.. code:: sh
-
-   sudo apt-get install netcat-openbsd
-
-After installing ``netcat-openbsd`` and appending the Tor config options
-to your local torrc, you can export the environment variable
-``SECUREDROP_SSH_OVER_TOR=1`` in order to use ``vagrant ssh`` to access the
-staging or prod instances over Tor. Here is an example of how that works:
-
-.. code:: sh
-
-    $ vagrant up --provision /prod/     # restricts SSH to Tor after final reboot
-    $ vagrant ssh-config app-prod       # will show incorrect info due to lack of env var
-    Host app-prod
-      HostName 127.0.0.1
-      User vagrant
-      Port 2201
-      UserKnownHostsFile /dev/null
-      StrictHostKeyChecking no
-      PasswordAuthentication no
-      IdentityFile /home/conor/.vagrant.d/insecure_private_key
-      IdentitiesOnly yes
-      LogLevel FATAL
-
-    $ vagrant ssh app-prod -c 'echo hello'   # will fail due to incorrect ssh-config
-    ssh_exchange_identification: read: Connection reset by peer
-
-    $ export SECUREDROP_SSH_OVER_TOR=1       # instruct Vagrant to use Tor for SSH
-    $ vagrant ssh-config app-prod            # will show correct info, with ProxyCommand
-    Host app-prod
-      HostName l57xhqhltlu323vi.onion
-      User vagrant
-      Port 22
-      UserKnownHostsFile /dev/null
-      StrictHostKeyChecking no
-      PasswordAuthentication no
-      IdentityFile /home/conor/.vagrant.d/insecure_private_key
-      IdentitiesOnly yes
-      LogLevel FATAL
-      ProxyCommand nc -x 127.0.0.1:9050 %h %p
-
-    $ # ensure ATHS values are active in local Tor config:
-    $ cat *-aths | sudo tee -a /etc/tor/torrc > /dev/null && sudo service tor reload
-    $ vagrant ssh app-prod -c 'echo hello'   # works
-    hello
-    Connection to l57xhqhltlu323vi.onion closed.
-
-If ``SECUREDROP_SSH_OVER_TOR`` is true, Vagrant will look up the ATHS URLs
-for each server by examining the contents of ``app-ssh-aths`` and ``mon-ssh-aths``
-in ``./install_files/ansible-base``. You can manually inspect these files
-to append values to your local ``torrc``, as in the ``cat`` example above.
-Note that the ``cat`` example above will also add the ATHS info for the
-*Journalist Interface*, as well, which is useful for testing.
-
-.. note:: The instructions above refer to VMs set up with v2 onion services. If
-          v3 onion services are configured instead, the steps required for the
-          local ``tor`` setup will differ. You will need to add a
-          ``ClientOnionAuthDir`` directive to ``torrc``, pointing to a directory
-          containing the ``*.auth_private`` files created during the installation
-          process under ``install_files/ansible-base``.
+Note that application dependency changes are suject to closer review, using
+`diffoscope` or a similar tool to compare the old and updated dependencies. You
+can request a review when submitting a PR.
 
 Architecture Diagrams
 ---------------------

--- a/docs/development/tips_and_tricks.rst
+++ b/docs/development/tips_and_tricks.rst
@@ -58,7 +58,7 @@ directly, please:
   #. Commit both the ``securedrop/requirements/python3/*.in`` and
      ``securedrop/requirements/python3/*.txt`` files
 
-Note that application dependency changes are suject to closer review, using
+Note that application dependency changes are subject to closer review, using
 `diffoscope` or a similar tool to compare the old and updated dependencies. You
 can request a review when submitting a PR.
 

--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -373,6 +373,5 @@ SSH Access
 
 By default, direct SSH access is not enabled in the prod environment. You will need to log
 in over Tor after initial provisioning or set ``enable_ssh_over_tor`` to "false"
-during ``./securedrop-admin tailsconfig``. See :ref:`ssh_over_tor` or :ref:`ssh_over_local`
-for more info.
+during ``./securedrop-admin tailsconfig``.
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -125,9 +125,7 @@ The third generation of onion services (v3) provides stronger cryptographic
 algorithms than v2 onion services, and includes redesigned protocols that
 guard against service information leaks on the Tor network.
 
-Support for v2 onion services will start to be removed from SecureDrop in
-February 2021, and we strongly recommend :doc:`upgrading SecureDrop
-instances to v3 onion services <v3_services>` as soon as possible.
+Only v3 onion services are supported by SecureDrop.
 
 OSSEC Alert Public Key
 ----------------------

--- a/docs/https_source_interface.rst
+++ b/docs/https_source_interface.rst
@@ -17,9 +17,7 @@ encryption and authentication via HTTPS:
 
 * SecureDrop supports v3 onion services, which use updated cryptographic
   primitives that provide better transport-layer encryption than those used
-  by v2 onion services. It is **strongly** recommended that you configure your
-  instance to use :doc:`v3 onion services <v3_services>`, but if you cannot
-  switch your instance to v3, using HTTPS on the source interface will provide
+  by v2 onion services. Using HTTPS on the source interface will provide
   an extra layer of encryption for data in transit.
 
 .. _`SecureDrop Directory`: https://securedrop.org/directory/
@@ -27,7 +25,10 @@ encryption and authentication via HTTPS:
 Obtaining an HTTPS certificate for Onion URLs
 ---------------------------------------------
 
-DigiCert is currently the only Certificate Authority (CA) that issues HTTPS
+Digicert
+~~~~~~~~
+
+DigiCert is one of only two Certificate Authorities (CA) that issue HTTPS
 certificates for ``.onion`` sites. DigiCert requires organizations to follow
 the Extended Validation (EV) process in order to obtain a certificate for an
 Onion URL, so you should start by reviewing `DigiCert's documentation`_ for
@@ -83,11 +84,19 @@ certificate a validity period of 12 months.
    Workstation, and avoiding copying the ``.key`` to any insecure removable
    media or other computers.
 
+Harica
+~~~~~~
+The Greek CA `Harica`_ is now providing Domain Validation (DV) certificates for
+``.onion`` addresses. DV certificates are less useful for authentication purposes,
+but may still be used to provide another layer of encryption for source traffic.
+
 .. _`specific URL`: https://docs.digicert.com/manage-certificates/organization-domain-management/managing-domains-cc-guide/add-authorize-domain-http-dcv/
 .. _`DigiCert's documentation`: https://www.digicert.com/dc/blog/ordering-a-onion-certificate-from-digicert/
 .. |HTTPS Onion cert| image:: images/screenshots/onion-url-certificate.png
 .. _`contact DigiCert directly`: https://www.digicert.com/dc/blog/ordering-a-onion-certificate-from-digicert/
 .. _`CAB Forum`: https://cabforum.org/2015/02/18/ballot-144-validation-rules-dot-onion-names/
+.. _`Harica`: https://www.harica.gr/
+
 
 Activating HTTPS in SecureDrop
 ------------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -52,18 +52,6 @@ parentheses.
           French to be available to read the documents and follow up in that
           language.
 
-Onion Service Options
----------------------
-SecureDrop supports the use of tradtional (v2)  or next-generation (v3) onion
-services for the *Source* and *Journalist Interfaces*, as well as the SSH proxy
-services if they are configured. Either or both may be enabled, but we recommend
-the use of v3 onion services for any new instances, as they offer greater
-security.
-
-For more information on v3 onion services, including upgrade options 
-for existing instances, see 
-:doc:`SecureDrop v3 onion services <v3_services>`.
-
 Configure the Installation
 --------------------------
 
@@ -171,32 +159,6 @@ Once the installation is complete, addresses and credentials for each
 onion service will be available in the following files under
 ``install_files/ansible-base``:
 
-V2 onion services
-^^^^^^^^^^^^^^^^^
-
-- ``app-source-ths`` contains the ``.onion`` address of the *Source
-  Interface*.
-- ``app-journalist-aths`` contains the ``HidServAuth``
-  configuration line for the *Journalist Interface*. During a later
-  step, this will be automatically added to your Tor configuration
-  file in order to exclusively limit connections to the hidden
-  service.
-- ``app-ssh-aths`` contains the ``HidServAuth`` for SSH access to the
-  *Application Server*.
-- ``mon-ssh-aths`` contains the ``HidServAuth`` for SSH access to the
-  *Monitor Server*.
-
-.. warning:: The ``app-journalist-aths``, ``app-ssh-aths``, and
-             ``mon-ssh-aths`` files contain passwords for their corresponding
-             authenticated onion services. They should not be shared with
-             third parties or copied from the *Admin Workstation* for any
-             reason other than well-defined administrative tasks such as
-             onboarding new users or performing backups.
-
-If v3 onion services are not enabled, the dynamic inventory file will 
-automatically read the Onion URLs from the ``app-ssh-aths`` and ``mon-ssh-aths``
-files and use them to connect to the servers over SSH during subsequent playbook
-runs.
 
 V3 onion services
 ^^^^^^^^^^^^^^^^^

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -69,20 +69,12 @@ Set Up Automatic Access to the *Journalist Interface*
 -----------------------------------------------------
 
 Since the *Journalist Interface* is an authenticated onion service, you must
-set up the *Journalist Workstation* to auto-configure Tor, similarly to 
+set up the *Journalist Workstation* to auto-configure Tor, similarly to
 the *Admin Workstation*. The procedure is essentially identical, except the
 SSH configuration will be skipped, since only admins need
 to access the servers over SSH.
 
-- First, boot into the *Admin Workstation*. If your instance has not been set up
-  to use v3 onion services, copy the following v2 service files to a *Transfer Device*:
-
-  .. code-block:: none
- 
-    ~/Persistent/securedrop/install_files/ansible_base/app-source-ths
-    ~/Persistent/securedrop/install_files/ansible_base/app-journalist-aths
-
-  If your instance was set up to use v3 services, copy the following files instead:
+- First, boot into the *Admin Workstation* and copy the following v3 service files to a *Transfer Device*:
 
   .. code-block:: none
 
@@ -91,9 +83,9 @@ to access the servers over SSH.
 
   Then, boot into the new *Journalist Workstation* USB.
 
-.. warning:: Do **not** copy the ``app-ssh-aths``, ``mon-ssh-aths``,
-             ``app-ssh.auth_private``, ``mon-ssh.auth_private``, or ``tor_v3_keys.json``
-             files to the *Journalist Workstation*. Those files contain private
+.. warning:: Do **not** copy the ``app-ssh.auth_private``,
+             ``mon-ssh.auth_private``, or ``tor_v3_keys.json`` files
+             to the *Journalist Workstation*. Those files contain private
              keys and authentication information for SSH server access.
              Only the *Admin Workstation* should have shell access to the
              servers.
@@ -116,17 +108,17 @@ to access the servers over SSH.
             due to network issues. If so, run it again before proceeding.
 
 - Once the ``tailsconfig`` command is complete, verify that the *Source* and
-  *Journalist Interfaces* are accessible at their v2 addresses via the 
+  *Journalist Interfaces* are accessible at their v3 addresses via the
   SecureDrop desktop shortcuts.
 
 - Securely wipe the files on the *Transfer Device*, by right-clicking them
   in the file manager and selecting **Wipe**.
 
 
-.. warning:: The ``app-journalist-aths`` and ``app-journalist.auth_private`` 
-             files contain secret authentication information for the
-             authenticated onion service used by the *Journalist Interface*,
-             and should not be shared except through the onboarding process.
+.. warning:: The ``app-journalist.auth_private`` file contains secret
+             authentication information for the authenticated onion service used
+             by the *Journalist Interface*, and should not be shared except
+             through the onboarding process.
 
 Add an account on the *Journalist Interface*
 --------------------------------------------

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -27,7 +27,7 @@ SecureDrop application environment consists of three dedicated computers:
    Onion Service, to send messages and documents to the journalist. The
    journalist connects to the *Journalist Interface*, an `authenticated Tor
    Onion Service
-   <https://gitweb.torproject.org/torspec.git/tree/rend-spec-v2.txt#n851>`__, to
+   <https://community.torproject.org/onion-services/advanced/client-auth/>`__, to
    download encrypted documents and respond to sources.
 - *Monitor Server*:
    An Ubuntu server that monitors the *Application Server*

--- a/docs/test_the_installation.rst
+++ b/docs/test_the_installation.rst
@@ -22,11 +22,11 @@ try using the verbose command format to troubleshoot: ::
    ssh <username>@<app .onion>
    ssh <username>@<mon .onion>
 
-.. tip:: If your instance uses v2 onion services, you can find the Onion
-         URLs for SSH in ``app-ssh-aths`` and ``mon-ssh-aths`` inside the
-         ``install_files/ansible-base`` directory. If your instance uses v3
-         onion services, check the ``app-ssh.auth_private`` and
-         ``mon-ssh.auth_private`` files instead.
+.. tip:: Check the ``app-ssh.auth_private`` and ``mon-ssh.auth_private`` files
+         in the ``install_files/ansible-base`` directory to find the ssh onion
+         service addresses. The files contain one line with 4 colon-delimited
+         fields. The address is the first 56-character field, just add a
+         ``.onion`` at the end.
 
 Log in to Both Servers via TTY
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/v3_services.rst
+++ b/docs/v3_services.rst
@@ -3,19 +3,20 @@ SecureDrop V3 Onion Services
 
 .. important::
 
-   SecureDrop instances must migrate to v3 onion services and Ubuntu 20.04
+   SecureDrop instances must migrate to v3 onion services and Ubuntu 20.04 (Focal)
    before April 30, 2021.
 
-   If your instance is still using 16-character v2 onion URLs as the
-   migration deadline approaches, the simplest solution is to follow the 
+   If your instance is still using 16-character v2 onion URLs after the
+   migration deadline, your *Source Interface* will be disabled automatically.
+   To restore access, you must migrate to Focal following the
    :ref:`Alternate Migration Procedure <migration_alternate>`.
 
-   Your SecureDrop's :ref:`Landing Page <glossary_landing_page>`
-   must be updated with your new 56-character onion address so sources
+   Your SecureDrop instance's :ref:`Landing Page <glossary_landing_page>`
+   must then be updated with your new 56-character onion address so sources
    can continue to reach you.
 
 .. note::
-  
+
    This documentation is applicable to servers running Ubuntu 16.04.
    It will be removed in a future release.
 
@@ -26,12 +27,11 @@ Because of these important improvements, the Tor project is
 `deprecating support for v2 onion services <https://blog.torproject.org/v2-deprecation-timeline>`__,
 and SecureDrop is also phasing out support for the v2 protocol.
 
-SecureDrop administrators should enable v3 onion services as soon as possible,
-while initially keeping v2 onion services running as well. Then, administrators
-should ensure that the new *Source Interface* URL is published on their instance's
-:ref:`Landing Page <glossary_landing_page>`, journalists have received new
-Tor credentials, and journalists and sources are aware of the change,
-before :ref:`disabling v2 onion services <disable_v2>`.
+SecureDrop administrators should enable v3 onion services as soon as possible.
+Then, administrators should ensure that the new *Source Interface* URL is
+published on their instance's :ref:`Landing Page <glossary_landing_page>`,
+journalists have received new Tor credentials, and journalists and sources are
+aware of the change.
 
 V3 onion addresses are 56 characters long, as in the following example:
 
@@ -50,22 +50,15 @@ How to Migrate from v2 to v3 Onion Services
 -------------------------------------------
 
    #. :ref:`Prepare backups <prepare_backups_v3>`
-   #. :ref:`Enable v3 onion services <enable_v3>` alongside v2, to avoid
-      disruption to journalists and sources
+   #. :ref:`Enable v3 onion services <enable_v3>` via a Focal migration
    #. :ref:`(Optional) Enable HTTPS <enable_https_v3>`
    #. :ref:`Update Tails workstations <update_tails_v3>` with the new v3 onion addresses
    #. :ref:`Publish <publish_v3>` your new *Source Interface* URL
-   #. Once you are satisfied with these changes, :ref:`disable v2 onion services<disable_v2>`.
 
 .. note:: If your instance currently uses
-          HTTPS with an EV certificate, please contact us via the `SecureDrop
-          support portal`_ or use `our GPG key`_ to send an encrypted email to
-          securedrop@freedom.press
-          before you proceed with the migration.
-	  If your certificate provisioning process requires validation of the
-          new v3 domain, you may not be able to complete the v3 migration
-          process
-          without first disabling HTTPS for v2.
+          HTTPS with an EV certificate, you may need to set up your v3 instance
+          to use HTTP first, then provision a new certificate with the v3
+          onion address.
 
 .. _SecureDrop Support portal: https://support-docs.securedrop.org/
 .. _our GPG key: https://securedrop.org/sites/default/files/fpf-email.asc
@@ -85,84 +78,9 @@ Before proceeding:
 Enable v3 onion services
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-- First, boot into the *Admin Workstation* with the persistent volume unlocked
-  and an admin password set.
-- Next, open a terminal via **Applications ▸ System Tools ▸ Terminal** and change
-  the working directory to the Securedrop application directory:
-
-  .. code:: sh
-
-    cd ~/Persistent/securedrop
-
-- Verify that SecureDrop version |version| is available or installed on
-  your instance with the command:
-
-  .. code:: sh
-
-    ssh app apt-cache policy securedrop-app-code
-
-  Version |version| should be listed as installed or as an installation candidate.
-- Verify that the *Admin Workstation*'s SecureDrop code is on |version|,
-  using the GUI updater or the command:
-
-  .. code:: sh
-
-    ./securedrop-admin update
-
-- After updating to the latest SecureDrop version, use the following command to
-  update ``securedrop-admin``'s dependencies:
-
-  .. code:: sh
-
-    ./securedrop-admin setup
-
-- Next, enable v3 onion services using:
-
-  .. code:: sh
-
-    ./securedrop-admin sdconfig
-
-  This command will step through the current instance configuration. None of the
-  current settings should be changed. When prompted to enable v2 and v3
-  services, you should choose ``yes`` to both.
-
-.. important::
-
-   There is no downgrade path from v3 to v2 using the ``securedrop-admin``
-   tool. We strongly recommend enabling v2 + v3 concurrently
-   to minimize the impact of the migration on sources and journalists.
-
-- Once the configuration has been updated, run the installation playbook using
-  the command:
-
-  .. code:: sh
-
-    ./securedrop-admin install
-
-  This will enable v3 onion services on the *Application* and *Monitor Servers*,
-  and may take some time to complete.
-
-- When the installation playbook run is complete, update the *Admin Workstation*
-  to use v3 onion services using the command:
-
-  .. code:: sh
-
-    ./securedrop-admin tailsconfig
-
-- Next, verify connectivity between the *Admin Workstation* and the SecureDrop
-  instance:
-
-  - Use the Source desktop shortcut to connect to the *Source Interface* and
-    verify that the new 56-character address is present in the Tor Browser
-    address bar.
-  - Use the Journalist desktop shortcut to connect to the *Journalist Interface*
-    and verify that the new 56-character address is present in the Tor Browser
-    address bar.
-  - Use the commands ``ssh app`` and ``ssh mon`` in a terminal to verify
-    SSH access to the *Application* and *Monitor Servers*.
-
-- Finally, back up the instance and *Admin Workstation* USB again. Do not
-  skip this step.
+- Follow the :ref:`Alternate Migration Procedure <migration_alternate>` to
+  set up a Focal v3 instance and migrate your instance's data and user
+  accounts.
 
 .. _enable_https_v3:
 
@@ -182,15 +100,12 @@ You'll find the new *Source Interface* address in the file:
 Follow the instructions in :doc:`HTTPS on the Source Interface <https_source_interface>`
 to provision and install the new certificate.
 
-
 .. _update_tails_v3:
 
 Update Workstation USBs
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-If you followed our recommendations, your other *Admin* and
-*Journalist Workstations* will still work over the old v2 protocol until that
-is disabled. Even so, you should update all workstations to use v3 services as
+You must  update all *Admin* and *Journalist Workstations* to use v3 services as
 soon as possible, for security reasons and to avoid future breakage.
 
 Journalist Workstation:
@@ -302,69 +217,6 @@ new *Source Interface* address as well, so that our Support team can
 continue to provide you with outage alerts.
 
 .. _Support Portal: https://support-docs.securedrop.org/
-
-.. _disable_v2:
-
-Disable v2 onion services
-^^^^^^^^^^^^^^^^^^^^^^^^^
-Once you've successfully enabled v3 onion services and updated your
-workstations, you should disable v2 onion services altogether.
-
-Coordinate with journalists to ensure that any ongoing
-source conversations are not interrupted. Journalists
-can use SecureDrop's reply feature to give active sources advance notice of
-the address change.
-
-When you're ready, follow the steps below to transition to v3 services only:
-
-- First, boot into the *Admin Workstation* with the persistent volume unlocked
-  and an admin password set.
-
-- Open a terminal and change the working directory to the SecureDrop application
-  directory with the command:
-
-  .. code:: sh
-
-    cd ~/Persistent/securedrop
-
-- Next, update the application configuration using the command:
-
-  .. code:: sh
-
-    ./securedrop-admin sdconfig
-
-  This command will step through the current instance configuration. When prompted,
-  you should type ``no`` for v2 services and ``yes`` for v3 services to migrate to
-  v3 only. No other settings should be modified.
-
-- Once the configuration has been updated, run the installation playbook using
-  the command:
-
-  .. code:: sh
-
-    ./securedrop-admin install
-
-  This will disable v2 onion services on the *Application* and *Monitor Servers*.
-
-- When the installation playbook run is complete, update the *Admin Workstation*
-  to use v3 onion services only using the command:
-
-  .. code:: sh
-
-    ./securedrop-admin tailsconfig
-
-- Next, verify connectivity between the *Admin Workstation* and the SecureDrop
-  instance, checking the desktop shortcuts and SSH access.
-
-- Then back up the instance and *Admin Workstation* USB.
-
-- Finally, update your other *Admin Workstations*: from a terminal, run:
-
-  .. code:: sh
-
-    ./securedrop-admin sdconfig   # choose "no" for v2, "yes" for v3
-    ./securedrop-admin tailsconfig
-
 
 Human-readable onion URLs
 -------------------------


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

* Description: 

* Fixes #207 

Removes references to v2 services in installation, migration, onboarding, and development docs. For posterity, v2 references in older upgrade documents have been left intact, but the v3 services docs referring to v2+v3 transitions have been updated to recommend a Focal migration instead.

## Testing

- [ ] CI good
- [ ] Docs changes are clear and correct
- [ ] No non-historical refs to v2 services

## Release 
* Should be released with SD version including changes in https://github.com/freedomofpress/securedrop/pull/5915


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000