### PR TITLE
make build-debs requires py-enchant

### DIFF
--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -40,6 +40,7 @@ Debian packages on the staging machines:
 
 .. code:: sh
 
+   sudo apt install python-enchant
    make build-debs
    make staging
    molecule login -s libvirt-staging-focal -h app-staging


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Description: 
`make build-debs` requires py-enchant

* Fixes Issue#
I searched through the tickets and I couldn't see any relevant ticket for this

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
no test needed

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
imo this change can go straight to `main` (i.e. latest doc)


## Checklist (Optional)

- [ X] Doc linting (`make docs-lint`) passed locally
- [X] Doc link linting (`make docs-linkcheck`) passed
- [X ] You have previewed (`make docs`) docs at http://localhost:8000