### PR TITLE
Remove references to the flag-for-reply workflow.

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -553,23 +553,6 @@ Response 200:
     "message": "Star removed"
   }
 
-Flag a source
-^^^^^^^^^^^^^
-
-Requires authentication.
-
-.. code:: sh
-
-  POST /api/v1/sources/<source_uuid>/flag
-
-Response 200:
-
-.. code:: json
-
-  {
-    "message": "Source flagged for reply"
-  }
-
 Submissions
 -----------
 

--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -776,3 +776,21 @@ response body:
 
 None of the requested items will be marked seen if any of them cannot
 be found.
+
+
+Removed functionality
+~~~~~~~~~~~~~~~~~~~~~
+
+Flagging sources
+----------------
+
+Previous versions of the API supported flagging sources for reply, which would
+generate a reply keypair for the source upon their next login. This
+functionality was removed in SecureDrop 2.0.0.
+
+The ``/api/v1/sources/<source_uuid>/flag`` endpoint (``POST``) and the
+``is_flagged`` property for sources are retained for backwards compatibility,
+but no longer function. ``is_flagged`` is always ``false``.
+
+The endpoint and the ``is_flagged`` property will be fully removed from the API
+in a future release.

--- a/docs/images/manual/screenshots/journalist-col_flagged.png
+++ b/docs/images/manual/screenshots/journalist-col_flagged.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ac62bcacc76ed15e715a8a5873ab152b18e913d3977205326a587c4db058c04
-size 100079

--- a/docs/images/manual/screenshots/journalist-col_has_no_key.png
+++ b/docs/images/manual/screenshots/journalist-col_has_no_key.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:040359d8dbae0ef38809c4b02a36e9536a531e547faecc1a27c2a66eeae55fbd
-size 88573

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -142,27 +142,6 @@ the *Submission Private Key*. To recall the conversation history between your
 organization and sources, you can also download replies and transfer them to
 the *Secure Viewing Station* for decryption.
 
-Flag for Reply
-~~~~~~~~~~~~~~
-
-If the server experiences a large number of new sources signing up at
-once and is overloaded with submissions, you will need to flag sources
-for reply before you can communicate with them. Click the **Flag this
-source for reply** button.
-
-|Flag for reply button|
-
-After clicking the **Flag this source for reply** button, you will see
-this confirmation page. Click through to get back to the page that
-displays that source's documents and replies.
-
-|Flag for reply notification|
-
-You will not be able to reply until after the source logs in again and
-sees that you would like to talk to them. So you may have to sit and wait.
-After the source sees that you'd like to reply, a GPG key pair will
-automatically be generated and you can log back in and send a reply.
-
 Moving Documents to the *Secure Viewing Station*
 ------------------------------------------------
 
@@ -709,8 +688,6 @@ bottom of the page. You will be prompted for confirmation:
 .. |Decrypted documents| image:: images/manual/viewing3.png
 .. |Opened document| image:: images/manual/viewing4.png
 .. |Sent reply| image:: images/manual/screenshots/journalist-composes_reply.png
-.. |Flag for reply button| image:: images/manual/screenshots/journalist-col_has_no_key.png
-.. |Flag for reply notification| image:: images/manual/screenshots/journalist-col_flagged.png
 .. |Delete sources| image:: images/manual/screenshots/journalist-delete_sources.png
 .. |Delete individual submissions| image:: images/manual/screenshots/journalist-delete_submissions.png
 .. |Delete source account| image:: images/manual/screenshots/journalist-delete_source_account.png

--- a/docs/source.rst
+++ b/docs/source.rst
@@ -16,21 +16,21 @@ Source Guide
    communications with them. If you plan to use SecureDrop to maintain your
    anonymity, you should not discuss your own use of it with others via unsafe
    methods, including email to Freedom of the Press Foundation.
-   
+
 What is SecureDrop?
 ---------------------------
 
-Dozens of news organizations — from *ProPublica* to *The New York Times* — use 
-SecureDrop to accept tips securely and anonymously. You can reach out and share 
-files, and messages, but for real anonymity, it’s important to take some extra 
-precautions. This resource will describe things you can do to help protect your 
+Dozens of news organizations — from *ProPublica* to *The New York Times* — use
+SecureDrop to accept tips securely and anonymously. You can reach out and share
+files, and messages, but for real anonymity, it’s important to take some extra
+precautions. This resource will describe things you can do to help protect your
 anonymity when using SecureDrop.
 
-Before moving ahead, note that your Internet Service Provider, or ISP (e.g., 
-Comcast), may already have a record of your visit to this website, 
-docs.securedrop.org. Likewise, any related activity should be conducted outside 
-of your workplace; if you are reading this page on a workplace device or 
-network, they may also have a record of that. 
+Before moving ahead, note that your Internet Service Provider, or ISP (e.g.,
+Comcast), may already have a record of your visit to this website,
+docs.securedrop.org. Likewise, any related activity should be conducted outside
+of your workplace; if you are reading this page on a workplace device or
+network, they may also have a record of that.
 
 Here are some things you can do to further minimize risk.
 
@@ -40,9 +40,9 @@ Choosing the Right Location
 
 If you don’t have sensitive information to send to a news organization, it may
 be okay to use a traditional computer when reaching out. But when sensitive
-disclosures (e.g., national security) are involved, we suggest you buy a new 
-computer and a USB flash drive, using cash. Either way, you should then find a 
-busy cafe you don’t regularly go to and sit at a place with your back to a 
+disclosures (e.g., national security) are involved, we suggest you buy a new
+computer and a USB flash drive, using cash. Either way, you should then find a
+busy cafe you don’t regularly go to and sit at a place with your back to a
 wall to avoid cameras capturing information on your screen or keystrokes.
 
 Get Tor Browser
@@ -75,14 +75,14 @@ last time you used Tor Browser.
 
 In general, when you are trying to stay anonymous, many time-saving features of
 your computer or phone turn into threats: bookmarks, recommendations,
-synchronization features, shortcuts to frequently opened files, and so on. This 
+synchronization features, shortcuts to frequently opened files, and so on. This
 is why using a dedicated computer for whistleblowing activities is generally safer.
 
 For greater deniability and security, we recommend booting the computer into the
 `Tails operating system`_ (typically from a USB stick). Tails is specifically
 designed to run on your computer without leaving traces of your activity or
 saving logs. It automatically routes all of your Internet browsing through Tor
-so you can easily access SecureDrop safely. This may take some additional 
+so you can easily access SecureDrop safely. This may take some additional
 technical steps, but it’s safer, and fairly simple to get started.
 
 Even if you are using a dedicated computer for your SecureDrop activity that you
@@ -107,8 +107,8 @@ We recommend conducting all research related to your submission in Tor Browser.
 If you are unsure whether you are using Tor, you can visit the address
 https://check.torproject.org.
 
-All organizations operating SecureDrop have a *landing page* that provides their 
-own organization-specific recommendations for using SecureDrop. We encourage 
+All organizations operating SecureDrop have a *landing page* that provides their
+own organization-specific recommendations for using SecureDrop. We encourage
 you to consider an organization’s *landing page* before submitting to them.
 
 .. note::
@@ -149,9 +149,9 @@ Browser to visit the organization's SecureDrop.
 Making Your First Submission
 ----------------------------
 
-Open Tor Browser and navigate to the .onion address for the SecureDrop you wish 
-to make a submission to. The page should look similar to the screenshot below, 
-although it will probably have a logo specific to the organization you are 
+Open Tor Browser and navigate to the .onion address for the SecureDrop you wish
+to make a submission to. The page should look similar to the screenshot below,
+although it will probably have a logo specific to the organization you are
 submitting to:
 
 |Source Interface with Javascript Disabled|
@@ -270,17 +270,6 @@ below message.
 
 |Delete received messages|
 
-If the server is experiencing a surge in traffic, you may see the message below:
-
-|Check for an initial response|
-
-This will only happen once for a given codename. It means that the journalist
-wants to reply to your submission, but for security reasons, they cannot do so
-until you've seen this message. Log in again at a later time to see if the
-journalist has responded.
-
-Repeat these steps to continue communicating with the journalist.
-
 .. |Source Interface Security Slider Warning| image:: images/manual/securedrop-security-slider-warning.png
 .. |Security Slider| image:: images/manual/source-turn-slider-to-high.png
 .. |Fix Javascript warning| image:: images/manual/security-slider-high.png
@@ -301,5 +290,3 @@ Repeat these steps to continue communicating with the journalist.
   image:: images/manual/screenshots/source-checks_for_reply.png
 .. |Delete received messages|
   image:: images/manual/screenshots/source-deletes_reply.png
-.. |Check for an initial response|
-  image:: images/manual/screenshots/source-flagged.png


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updates the docs after removal of the flag-for-reply workflow in https://github.com/freedomofpress/securedrop/pull/5954.


## Testing

Not much to check with deletions, but I am interested in whether others think we should retain the API endpoint documentation. I decided it was just confusing, since the endpoint now does nothing.

## Release 

This should be merged after https://github.com/freedomofpress/securedrop/pull/5954.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000