### PR TITLE
Fix multiple `ansible-base` path typos and add script to detect them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ docs:  ## Build project documentation with live reload for editing.
 
 .PHONY: docs-lint
 docs-lint:  ## Check documentation for common syntax errors.
+	@echo "███ Checking for common errors..."
+	@./check_errors.sh
 	@echo "███ Linting documentation..."
 # The `-W` option converts warnings to errors.
 # The `-n` option enables "nit-picky" mode.
@@ -19,5 +21,5 @@ docs-linkcheck:  ## Check documentation for broken links.
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: 
+%:
 	@sphinx-build -M $@ docs/ docs/_build/html

--- a/check_errors.sh
+++ b/check_errors.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# Check for common errors in the documentation and exit 1 if any are found.
+if grep -R --exclude-dir='_build' ansible_base docs/; then
+  echo "Found reference to 'ansible_base' path name in the documentation."
+  echo "The correct path name is 'ansible-base'."
+  exit 1
+fi
+
+echo "No common errors found."
+exit 0

--- a/docs/development/qubes_staging.rst
+++ b/docs/development/qubes_staging.rst
@@ -333,23 +333,23 @@ to the *Journalist Interface* (staging).
 In ``sd-dev``
 ~~~~~~~~~~~~~
 
-You will have to copy the ``app-journalist.auth_private`` file (located in 
-your ``sd-dev`` VM in ``${SECUREDROP_HOME}/install_files/ansible_base`` and 
-generated after a successful staging build) into your Whonix gateway 
+You will have to copy the ``app-journalist.auth_private`` file (located in
+your ``sd-dev`` VM in ``${SECUREDROP_HOME}/install_files/ansible-base`` and
+generated after a successful staging build) into your Whonix gateway
 VM. On standard Qubes installations this VM is called ``sys-whonix``.
 
 To do this, in an ``sd-dev`` terminal, run the command:
 
 .. code:: sh
-   
-   qvm-copy ${SECUREDROP_HOME})/install_files/ansible_base/app-journalist.auth_private
 
-and select ``sys-whonix`` in the resulting permissions dialog. 
+   qvm-copy ${SECUREDROP_HOME})/install_files/ansible-base/app-journalist.auth_private
+
+and select ``sys-whonix`` in the resulting permissions dialog.
 
 In the Whonix Gateway
 ~~~~~~~~~~~~~~~~~~~~~
 
-Open a terminal in ``sys-whonix`` and create a directory with appropriate 
+Open a terminal in ``sys-whonix`` and create a directory with appropriate
 ownership and permissions, then move your credential file there:
 
 .. code:: sh
@@ -358,7 +358,7 @@ ownership and permissions, then move your credential file there:
    sudo mv ~/QubesIncoming/sd-dev/app-journalist.auth_private /var/lib/tor/onion_auth
    sudo chown --recursive debian-tor:debian-tor /var/lib/tor/onion_auth
 
-Next, edit the Tor configuration so it recognizes the directory 
+Next, edit the Tor configuration so it recognizes the directory
 containing your credentials:
 
 .. code:: sh

--- a/docs/offboarding.rst
+++ b/docs/offboarding.rst
@@ -212,7 +212,7 @@ On the Admin Workstation
 #. Take the *Transfer Device* with the new *Submission Public Key* and
    fingerprint to your *Admin Workstation*. As you did during the initial
    install, copy the public key, ``SecureDrop.asc``, to the
-   ``install_files/ansible_base/`` directory, replacing the existing public
+   ``install_files/ansible-base/`` directory, replacing the existing public
    key file that is there.
 
 
@@ -222,7 +222,7 @@ On the Admin Workstation
 
       ./securedrop-admin sdconfig
 
-   If the new public key that you placed in ``install_files/ansible_base``
+   If the new public key that you placed in ``install_files/ansible-base``
    has the same name as the old public key, ``SecureDrop.asc``, the
    only part of the configuration you will change is the SecureDrop
    *Submission Key* fingerprint, which you will update with the fingerprint
@@ -262,7 +262,7 @@ Return to the Secure Viewing Station
 
 
 #. If you have any other *Admin Workstations*, make sure that you have copied
-   the new *Submission Public Key* into the ``install_files/ansible_base``
+   the new *Submission Public Key* into the ``install_files/ansible-base``
    directory, replacing the old public key file, and updated the *Submission
    Public Key* fingerprint by running
 

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -78,8 +78,8 @@ to access the servers over SSH.
 
   .. code-block:: none
 
-    ~/Persistent/securedrop/install_files/ansible_base/app-sourcev3-ths
-    ~/Persistent/securedrop/install_files/ansible_base/app-journalist.auth_private
+    ~/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths
+    ~/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private
 
   Then, boot into the new *Journalist Workstation* USB.
 
@@ -99,7 +99,7 @@ to access the servers over SSH.
 - Open a terminal and run the following commands:
 
   .. code:: sh
- 
+
     cd ~/Persistent/securedrop
     ./securedrop-admin setup
     ./securedrop-admin tailsconfig


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

I don't know where the `install_files/ansible-base` underscore/dash naming convention originates, but it unsurprisingly leads to a lot of typos, including in our documentation. I've fixed the ones I've found, and added a small checker script so CI will yell on future errors of this type.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000