### PR TITLE
Fix subnet recommendation for staging in Qubes OS

### DIFF
--- a/docs/development/qubes_staging.rst
+++ b/docs/development/qubes_staging.rst
@@ -65,12 +65,12 @@ Next, choose **Install Ubuntu**.
 For the most part, the install process matches the
 :ref:`hardware install flow <install_ubuntu>`, with a few exceptions:
 
-  -  Server IP address: use value returned by ``qvm-prefs sd-staging-base-focal ip``,
-     with ``/24`` netmask suffix
-  -  Gateway: use value returned by ``qvm-prefs sd-staging-base-focal visible_gateway``
-  -  For DNS, use Qubes's DNS servers: ``10.139.1.1`` and ``10.139.1.2``.
-  -  Hostname: ``sd-staging-base-focal``
-  -  Domain name should be left blank
+  -  **Subnet:** 10.137.0.0/24
+  -  **Address:** use value returned by ``qvm-prefs sd-staging-base-focal ip``
+  -  **Gateway:** use value returned by ``qvm-prefs sd-staging-base-focal visible_gateway``
+  -  **Name servers:** 10.139.1.1,10.139.1.2
+  -  **Search domains:** *should be left blank*
+  -  **Your server's name:** ``sd-staging-base-focal``
 
 Make sure to configure LVM and use **Virtual disk 1 (xvda 20.0GB Xen Virtual Block device)**
 when asked for a target partition during installation. It should be the default option.

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -206,7 +206,7 @@ If you did not, adjust these settings accordingly.
   -  **Address:** 10.20.2.2
   -  **Gateway:** 10.20.2.1
   -  **Name servers:** 8.8.8.8, 8.8.4.4
-  -  **Search Domains:** *should be left blank*
+  -  **Search domains:** *should be left blank*
 
 -  *Monitor Server*:
 
@@ -214,7 +214,7 @@ If you did not, adjust these settings accordingly.
   -  **Address:** 10.20.3.2
   -  **Gateway:** 10.20.3.1
   -  **Name servers:** 8.8.8.8, 8.8.4.4
-  -  **Search Domains:** *should be left blank*
+  -  **Search domains:** *should be left blank*
 
 Select **Save** and press **Enter** to apply your settings. Then select **Done** and press **Enter**.
 


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

- Updates the list of fields that are required by the Ubuntu 20.04 (Focal) installer
- Rename the _hostname_ field as named in the installer, and move it down because it is required in a later step to the network settings
- Modifies the subnet recommendation in for staging in Qubes OS in order to ensure that the resulting machines have access to the network

Fixes #209 
Fixes #211 

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] Review the list of fields required by the installer
- [ ] Check that `10.137.0.0/24` indeed contains the likely IPs of both `sd-staging-base-focal` and its gateway

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
_No special considerations for release come to my mind._


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000