### PR TITLE
Add /sources/{uuid}/conversation endpoint to API docs

### DIFF
--- a/docs/development/journalist_api.rst
+++ b/docs/development/journalist_api.rst
@@ -502,6 +502,23 @@ Response 200:
     "message": "Source and submissions deleted"
   }
 
+Delete a source conversation (messages/files/replies) while preserving the source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Requires authentication.
+
+.. code:: sh
+
+  DELETE /api/v1/sources/<source_uuid>/conversation
+
+Response 200:
+
+.. code:: json
+
+  {
+    "message": "Source data deleted"
+  }
+
 Star a source
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

* Description: Documents `/sources/{uuid}/conversation` endpoint


## Testing
- [x] CI's good
- [x] changes are coherent, consistent with the changes introduced in https://github.com/freedomofpress/securedrop/pull/5963
