### PR TITLE
starts "Accessibility" section in "Contributor Guidelines"

### DIFF
--- a/docs/development/contributor_guidelines.rst
+++ b/docs/development/contributor_guidelines.rst
@@ -96,6 +96,22 @@ our HTML templates in ``securedrop/source_templates`` and
 
       make html-lint
 
+Accessibility
+^^^^^^^^^^^^^
+
+SecureDrop's accessibility guidelines and tooling are a work in progress.  At
+a minimum, if you make changes involving images, make sure they have ``alt``
+attributes in accordance with the W3C's `"alt decision tree"
+<https://www.w3.org/WAI/tutorials/images/decision-tree/>`_, so that the
+interfaces will be navigable by people using screen-readers. For more-involved
+changes to the UIs, consult resources such as `the A11y Project checklist
+<https://www.a11yproject.com/checklist/>`_.
+
+If you have accessibility expertise to offer, the `"a11y" label
+<https://github.com/freedomofpress/securedrop/labels/a11y>`_ in GitHub is a
+great place to contribute.
+
+
 YAML
 ~~~~
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves freedomofpress/securedrop#5743.

The broader goal here is not remotely to propose definitive accessibility guidelines for all of SecureDrop, just to reflect where things currently stand, to be expanded in the course of freedomofpress/securedrop#5972.  (For example, this probably shouldn't remain a subsection of "HTML" for long.)

## Testing

Not applicable.

## Release 

Not applicable.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000