### PR TITLE
make bolded URLs actual URLs

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -133,13 +133,15 @@ network, the admin should ensure that critical security patches are applied to t
 firewall.
 
 Be informed of potential updates to your network firewall. If you're using the
-network firewall recommended by FPF, you can subscribe to email updates from the `Netgate homepage`_
-to be alerted when releases occur. If critical security updates need to be
-applied, you can do so through the firewall's pfSense WebGUI. Refer to our
-:ref:`Keeping pfSense up to date` documentation or the official `pfSense
-Upgrade Docs`_ for further details on how to update the suggested firewall.
+network firewall recommended by FPF, you can subscribe to email updates from
+the `Netgate homepage`_ or follow the `Netgate blog`_ to be alerted when
+releases occur. If critical security updates need to be applied, you can do so
+through the firewall's pfSense WebGUI. Refer to our :ref:`Keeping pfSense up to
+date` documentation or the official `pfSense Upgrade Docs`_ for further details
+on how to update the suggested firewall.
 
 .. _`Netgate homepage`: https://www.netgate.com/
+.. _`Netgate blog`: https://www.netgate.com/blog/
 .. _`pfSense Upgrade Docs`: https://docs.netgate.com/pfsense/en/latest/install/upgrade-guide.html
 
 Updates: Workstations

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -133,13 +133,13 @@ network, the admin should ensure that critical security patches are applied to t
 firewall.
 
 Be informed of potential updates to your network firewall. If you're using the
-network firewall recommended by FPF, you can subscribe to the `Netgate RSS Feed`_
+network firewall recommended by FPF, you can subscribe to email updates from the `Netgate homepage`_
 to be alerted when releases occur. If critical security updates need to be
 applied, you can do so through the firewall's pfSense WebGUI. Refer to our
 :ref:`Keeping pfSense up to date` documentation or the official `pfSense
 Upgrade Docs`_ for further details on how to update the suggested firewall.
 
-.. _`Netgate RSS Feed`: https://www.netgate.com/feed.xml
+.. _`Netgate homepage`: https://www.netgate.com/
 .. _`pfSense Upgrade Docs`: https://docs.netgate.com/pfsense/en/latest/install/upgrade-guide.html
 
 Updates: Workstations

--- a/docs/development/dockerbuildmaint.rst
+++ b/docs/development/dockerbuildmaint.rst
@@ -4,9 +4,9 @@ Build container
 ===============
 We use a Docker build container to build our debian packages for SecureDrop (via ``make build-debs``
 in the ``securedrop`` Github repository root directory). We keep images of this our container in a
-Docker repository at **quay.io/freedomofpress**. The images are organized by Ubuntu release
+Docker repository at https://quay.io/freedomofpress. The images are organized by Ubuntu release
 version. For instance, you can find the images for Focal at
-**quay.io/freedomofpress/sd-docker-builder-focal**.
+https://quay.io/freedomofpress/sd-docker-builder-focal.
 
 Maintaining images of our build container for each release is our way of recording the exact version
 of each dependency used to build our production debian packages for SecureDrop.

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -737,11 +737,9 @@ If you see that an update is available, we recommend installing it. Most
 of these updates are for minor bugfixes, but occasionally they can
 contain important security fixes. You should keep apprised of updates
 yourself by checking the `pfSense Blog posts with the "releases"
-tag <https://www.netgate.com/blog/category.html#releases>`__.
+tag <https://www.netgate.com/blog/tag/releases>`__.
 
-.. note:: Protip: Subscribe to the `RSS feed`_.
-
-.. _RSS feed: https://www.netgate.com/feed.xml
+.. note:: You can subscribe to email updates on https://www.netgate.com.
 
 To install the update, click the Download icon next to the update then click
 the "Confirm" button:


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Just came across this again and now addressing @conorsch's comment from another pr: https://github.com/freedomofpress/securedrop-docs/pull/137/files#r589575482

Also fixed broken netgate links found by running `make docs-linkcheck`.

## Testing
* links work and take you to where you'd expect

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
