### PR TITLE
Mitigate absence of images in the User Guides

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -394,7 +394,7 @@ only want to receive text messages, you can disable uploads as follows:
 #. Click **Update Submission Preferences**
 
 This change will be applied immediately on the *Source Interface*. Documents that
-were previously uploaded will still be available via the **Journalist Interface**.
+were previously uploaded will still be available via the *Journalist Interface*.
 
 .. _test OSSEC alert:
 

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -250,20 +250,20 @@ smartphone authenticator app or a Yubikey for two-factor authentication. If an
 app is to be used, the journalist should install it before proceeding with the
 account setup.
 
-  .. include:: includes/otp-app.txt
+.. include:: includes/otp-app.txt
 
-* Click **Admin** in the top right corner of the page to load the *Admin Interface*.
+#. Click **Admin** in the top right corner of the page to load the *Admin Interface*.
 
-  |SecureDrop admin home|
+   |SecureDrop admin home|
 
-* Click **Add User** to add a new user.
+#. Click **Add User** to add a new user.
 
-  |Add a new user|
+   |Add a new user|
 
-* Hand the keyboard over to the journalist so they can create their own username.
-* Once they’re done entering a username for themselves, have them save their pre-generated diceware passphrase to their password manager.
-* If the new account should also have admin privileges, allowing them to add or delete other journalist accounts, select **Is Admin**.
-* Finally, set up two-factor authentication for the account, following one of the two procedures below for your chosen method.
+#. Hand the keyboard over to the journalist so they can create their own username.
+#. Once they’re done entering a username for themselves, have them save their pre-generated Diceware passphrase to their password manager.
+#. If the new account should also have admin privileges, allowing them to add or delete other journalist accounts, select **Is Admin**.
+#. Finally, set up two-factor authentication for the account, following one of the two procedures below for your chosen method.
 
 .. note::
    The username **deleted** is reserved, as it is used to mark accounts which
@@ -273,13 +273,13 @@ account setup.
 FreeOTP
 #######
 
-* If the journalist is using FreeOTP or another app for two-factor authentication, click **Add User** to proceed to the next page.
+#. If the journalist is using FreeOTP or another app for two-factor authentication, click **Add User** to proceed to the next page.
 
    |Enable FreeOTP|
 
-* Next, the journalist should open FreeOTP on their smartphone and scan the barcode displayed on the screen.
-* If they have difficulty scanning the barcode, they can tap on the icon at the top that shows a plus and the symbol of a key and use their phone's keyboard to input the two-factor secret into the ``Secret`` input field, without whitespace.
-* Inside the FreeOTP app, a new entry for this account will appear on the main screen, with a six-digit number that recycles to a new number every thirty seconds.  The journalist should enter the six-digit number in the  **Verification code** field at the bottom of the **Enable FreeOTP** form and click **Submit**.
+#. Next, the journalist should open FreeOTP on their smartphone and scan the barcode displayed on the screen.
+#. If they have difficulty scanning the barcode, they can tap on the icon at the top that shows a plus and the symbol of a key and use their phone's keyboard to input the two-factor secret into the ``Secret`` input field, without whitespace.
+#. Inside the FreeOTP app, a new entry for this account will appear on the main screen, with a six-digit number that recycles to a new number every thirty seconds.  The journalist should enter the six-digit number in the  **Verification code** field at the bottom of the **Enable FreeOTP** form and click **Submit**.
 
 If two-factor authentication was set up successfully, you will be redirected back
 to the *Admin Interface* and will see a confirmation that the two-factor code was
@@ -288,15 +288,15 @@ verified.
 YubiKey
 #######
 
-* If the journalist wishes to use a YubiKey for two-factor authentication, select **Is using a YubiKey**. You will then need to enter their YubiKey's OATH-HOTP Secret Key. For more information on how to retrieve this key, read the :doc:`YubiKey Setup Guide <yubikey_setup>`.
+#. If the journalist wishes to use a YubiKey for two-factor authentication, select **Is using a YubiKey**. You will then need to enter their YubiKey's OATH-HOTP Secret Key. For more information on how to retrieve this key, read the :doc:`YubiKey Setup Guide <yubikey_setup>`.
 
    |Enable YubiKey|
 
-* Once you've entered the Yubikey's OATH-HOTP Secret Key, click **Add User**.  On the next page, have the journalist authenticate using their YubiKey, by inserting it into a USB port on the workstation and pressing its button.
+#. Once you've entered the Yubikey's OATH-HOTP Secret Key, click **Add User**.  On the next page, have the journalist authenticate using their YubiKey, by inserting it into a USB port on the workstation and pressing its button.
 
    |Verify YubiKey|
 
-* If everything was set up correctly, you will be redirected back to the *Admin Interface*, where you should see a flashed message that says "The two-factor code for user *new username* was verified successfully.".
+#. If everything was set up correctly, you will be redirected back to the *Admin Interface*, where you should see a flashed message that says "The two-factor code for user *new username* was verified successfully.".
 
 The journalist will require their username, passphrase, and two-factor authentication
 method whenever they check SecureDrop. Make sure that they have memorised their
@@ -319,27 +319,29 @@ can happen if, for example, they lose their two-factor device or if they
 forget the passphrase to their password manager. When this happens, you
 can reset their account as follows:
 
-* Log in as an administrator to the *Journalist Interface* and select *Admin* at
-  the top right to open the *Admin Interface*.
+#. Log in as an administrator to the *Journalist Interface*
+#. Select *Admin* at the top right to open the *Admin Interface*
+#. Find the user's account name and select **Edit**
 
 |Reset Passphrase|
 
 Next, you can either rotate their passphrase or reset two-factor authentication
 for their account.
 
-* To change their passphrase to the randomly-generated passphrase shown, first
-  make sure the new passphrase is saved in a password manager, then select **Reset Password**.
+To change their passphrase to the randomly-generated passphrase shown:
 
-* To reset two-factor authentication, click the button that corresponds to the user's
-  chosen two-factor authentication method:
+  #. Have the journalist enter their current passphrase and two-factor code.
+  #. Make sure the new passphrase is saved in a password manager.
+  #. Click **Reset Password**
 
-  * Click **Reset Mobile App Credentials** for accounts using FreeOTP or a similar
-    authentication app.
+To reset two-factor authentication:
 
-  * Click **Reset Security Key Credentials** for accounts using a Yubikey.
+  #. Click the button that corresponds to the user's chosen two-factor authentication method:
 
-* Follow the on-screen instructions to complete the process and verify their new
-  two-factor authentication credentials.
+     * Click **Reset Mobile App Credentials** for accounts using FreeOTP or a similar authentication app
+     * Click **Reset Security Key Credentials** for accounts using a Yubikey
+
+  #. Follow the on-screen instructions to complete the process and verify their new two-factor authentication credentials.
 
 
 Off-boarding Users
@@ -372,9 +374,9 @@ You can update the system logo shown on the web interfaces of your SecureDrop
 instance via the *Admin Interface*. We recommend a size of ``500px x 450px``. Only
 PNG-format images are supported. To update the logo image:
 
-* copy the logo image to your admin workstation
-* click **Browse** and select the image from your workstation's filesystem
-* click **Update Logo** to upload and set the new logo.
+#. Copy the logo image to your admin workstation
+#. Click **Browse** and select the image from your workstation's filesystem
+#. Click **Update Logo** to upload and set the new logo
 
 You should see a message appear indicating the change was a success.
 
@@ -388,8 +390,8 @@ Setting Submission Preferences
 By default, SecureDrop supports both text submissions and document uploads. If you
 only want to receive text messages, you can disable uploads as follows:
 
-* check the the **Prevent sources from uploading documents** checkbox
-* click **Update Submission Preferences**
+#. Check the **Prevent sources from uploading documents** checkbox
+#. Click **Update Submission Preferences**
 
 This change will be applied immediately on the *Source Interface*. Documents that
 were previously uploaded will still be available via the **Journalist Interface**.
@@ -619,9 +621,9 @@ to perform common server administration tasks, including:
 
 To use ``securedrop-admin``:
 
-#. boot the *Admin Workstation* with persistence enabled and an admin password set
-#. open a terminal via **Applications > System Tools > Terminal**
-#. change directory to the SecureDrop installation directory: ``cd ~/Persistent/securedrop``
+#. Boot the *Admin Workstation* with persistence enabled and an admin password set
+#. Open a terminal via **Applications > System Tools > Terminal**
+#. Change directory to the SecureDrop installation directory: ``cd ~/Persistent/securedrop``
 
 You can list all available ``securedrop-admin`` actions using the command
 ``./securedrop-admin --help``

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -214,7 +214,7 @@ enabled and double-click the *Journalist Interface* icon on the Desktop. Tor Bro
 will start and load the login page for the *Journalist Interface*. Use your username,
 passphrase, and two-factor authentication token to log in.
 
-By default, you will be logged in to the *Journalist Interface*'s source list page:
+By default, you will be logged in to the *Journalist Interface*'s source list page.
 
 |SecureDrop main page|
 
@@ -252,50 +252,34 @@ account setup.
 
   .. include:: includes/otp-app.txt
 
-* First, click **Admin** in the top right corner of the page to load the *Admin Interface*:
+* Click **Admin** in the top right corner of the page to load the *Admin Interface*.
 
   |SecureDrop admin home|
 
-*  Once there, click **Add User** to add a new user:
+* Click **Add User** to add a new user.
 
-|Add a new user|
+  |Add a new user|
 
-* Next, hand the keyboard over to the journalist so they can
-  create their own username.
+* Hand the keyboard over to the journalist so they can create their own username.
+* Once they’re done entering a username for themselves, have them save their pre-generated diceware passphrase to their password manager.
+* If the new account should also have admin privileges, allowing them to add or delete other journalist accounts, select **Is Admin**.
+* Finally, set up two-factor authentication for the account, following one of the two procedures below for your chosen method.
 
-  .. note::
-    The username **deleted** is reserved, as it is used to mark accounts which
-    have been deleted from the system.
+.. note::
+   The username **deleted** is reserved, as it is used to mark accounts which
+   have been deleted from the system.
 
-* Once they’re done entering a username for themselves, have them save their
-  pre-generated diceware passphrase to their password manager.
-
-* If the new account should also have admin privileges, allowing them to add or
-  delete other journalist accounts, select **Is Admin**.
-
-* Finally, set up two-factor authentication for the account, following one of
-  the two procedures below for your chosen method.
 
 FreeOTP
 #######
 
-* If the journalist is using FreeOTP or another app for two-factor authentication,
-  click **Add User** to proceed to the next page.
+* If the journalist is using FreeOTP or another app for two-factor authentication, click **Add User** to proceed to the next page.
 
-|Enable FreeOTP|
+   |Enable FreeOTP|
 
-* Next, the journalist should open FreeOTP on their smartphone and scan the barcode
-  displayed on the screen.
-
-* If they have difficulty scanning the barcode, they can tap on the icon
-  at the top that shows a plus and the symbol of a key and use their
-  phone's keyboard to input the two-factor secret (highlighted
-  in yellow) into the ``Secret`` input field, without whitespace.
-
-* Inside the FreeOTP app, a new entry for this account will appear on the main
-  screen, with a six-digit number that recycles to a new number every thirty seconds.
-  The journalist should enter the six-digit number in the  **Verification code**
-  field at the bottom of the **Enable FreeOTP** form and click **Submit**.
+* Next, the journalist should open FreeOTP on their smartphone and scan the barcode displayed on the screen.
+* If they have difficulty scanning the barcode, they can tap on the icon at the top that shows a plus and the symbol of a key and use their phone's keyboard to input the two-factor secret into the ``Secret`` input field, without whitespace.
+* Inside the FreeOTP app, a new entry for this account will appear on the main screen, with a six-digit number that recycles to a new number every thirty seconds.  The journalist should enter the six-digit number in the  **Verification code** field at the bottom of the **Enable FreeOTP** form and click **Submit**.
 
 If two-factor authentication was set up successfully, you will be redirected back
 to the *Admin Interface* and will see a confirmation that the two-factor code was
@@ -304,22 +288,15 @@ verified.
 YubiKey
 #######
 
-* If the journalist wishes to use a YubiKey for two-factor authentication,
-  select **Is using a YubiKey**. You will then need to enter their YubiKey's
-  OATH-HOTP Secret Key. For more information on how to retrieve this key, read
-  the :doc:`YubiKey Setup Guide <yubikey_setup>`.
+* If the journalist wishes to use a YubiKey for two-factor authentication, select **Is using a YubiKey**. You will then need to enter their YubiKey's OATH-HOTP Secret Key. For more information on how to retrieve this key, read the :doc:`YubiKey Setup Guide <yubikey_setup>`.
 
-|Enable YubiKey|
+   |Enable YubiKey|
 
-* Once you've entered the Yubikey's OATH-HOTP Secret Key, click **Add User**.
-  On the next page, have the journalist authenticate using their YubiKey, by
-  inserting it into a USB port on the workstation and pressing its button.
+* Once you've entered the Yubikey's OATH-HOTP Secret Key, click **Add User**.  On the next page, have the journalist authenticate using their YubiKey, by inserting it into a USB port on the workstation and pressing its button.
 
-|Verify YubiKey|
+   |Verify YubiKey|
 
-* If everything was set up correctly, you will be redirected back to the
-  *Admin Interface*, where you should see a flashed message that says "The
-  two-factor code for user *new username* was verified successfully.".
+* If everything was set up correctly, you will be redirected back to the *Admin Interface*, where you should see a flashed message that says "The two-factor code for user *new username* was verified successfully.".
 
 The journalist will require their username, passphrase, and two-factor authentication
 method whenever they check SecureDrop. Make sure that they have memorised their
@@ -345,10 +322,10 @@ can reset their account as follows:
 * Log in as an administrator to the *Journalist Interface* and select *Admin* at
   the top right to open the *Admin Interface*.
 
-* Find the user's account name and select **Edit**.
+|Reset Passphrase|
 
 Next, you can either rotate their passphrase or reset two-factor authentication
-for their account:
+for their account.
 
 * To change their passphrase to the randomly-generated passphrase shown, first
   make sure the new passphrase is saved in a password manager, then select **Reset Password**.
@@ -364,7 +341,6 @@ for their account:
 * Follow the on-screen instructions to complete the process and verify their new
   two-factor authentication credentials.
 
-|Reset Passphrase|
 
 Off-boarding Users
 ^^^^^^^^^^^^^^^^^^
@@ -400,7 +376,7 @@ PNG-format images are supported. To update the logo image:
 * click **Browse** and select the image from your workstation's filesystem
 * click **Update Logo** to upload and set the new logo.
 
-You should see a message appear indicating the change was a success:
+You should see a message appear indicating the change was a success.
 
 |Logo Update|
 
@@ -423,16 +399,15 @@ were previously uploaded will still be available via the **Journalist Interface*
 Testing OSSEC Alerts
 ^^^^^^^^^^^^^^^^^^^^
 
-To verify that the OSSEC monitoring sysstem's functionality, you can send a test
-OSSEC alert by clicking **Send Test OSSEC Alert**:
+To verify that the OSSEC monitoring system's functionality, you can send a test
+OSSEC alert by clicking **Send Test OSSEC Alert**.
 
-          |Test Alert|
+|Test Alert|
 
 You should receive an OSSEC alert email at the address specified during the
 installation of SecureDrop. The email may take several minutes to arrive. If
 you don't receive it, refer to the :doc:`OSSEC Guide<ossec_alerts>` for information on
 troubleshooting steps.
-
 
 .. _server SSH access:
 
@@ -823,12 +798,20 @@ left off. However, if the same issue persists, you will need to investigate
 further.
 
 .. |Reset Passphrase| image:: images/manual/screenshots/journalist-edit_account_user.png
+   :alt: The account editing form allows admins to change name, reset passphrase, and reset two-factor authentication.
 .. |Test Alert| image:: images/manual/screenshots/journalist-admin_ossec_alert_button.png
+   :alt: The Instance Configuration form displays 'Test alert sent' after a test OSSEC alert was sent successfully.
 .. |SecureDrop main page| image:: images/manual/screenshots/journalist-admin_index_no_documents.png
+   :alt: The top navigation of the Journalist Interface says 'Logged on as Journalist' and displays an 'Admin' link.
 .. |SecureDrop admin home| image:: images/manual/screenshots/journalist-admin_interface_index.png
+   :alt: The Admin Interface displays an 'Add User' button.
 .. |Add a new user| image:: images/manual/screenshots/journalist-admin_add_user_totp.png
+   :alt: The form used to create new users displays a pre-generated Diceware passphrase.
 .. |Enable FreeOTP| image:: images/manual/screenshots/journalist-admin_new_user_two_factor_totp.png
+   :alt: The form used to enable FreeOTP displays a barcode and a two-factor secret.
 .. |Enable YubiKey| image:: images/manual/screenshots/journalist-admin_add_user_hotp.png
+   :alt: The form used to create new users, filled with the 40-character HOTP secret key of a Yubikey.
 .. |Verify YubiKey| image:: images/manual/screenshots/journalist-admin_new_user_two_factor_hotp.png
-.. |System Config Page| image:: images/manual/screenshots/journalist-admin_system_config_page.png
+   :alt: The form used to verify the setup of the Yubikey requests a 6-digit verification code.
 .. |Logo Update| image:: images/manual/screenshots/journalist-admin_changes_logo_image.png
+   :alt: The Instance Configuration form displays 'Image updated' after the logo was updated successfully.

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -281,7 +281,7 @@ a document with an incorrect or missing file extension.
 
 .. tip::
 
-   Always extract gzip archives with the **Archive Manager** application, which is
+   Always extract gzip archives with the *Archive Manager* application, which is
    the default when double-clicking the archive. Other methods may not preserve
    the filename contained in the archive.
 
@@ -292,7 +292,7 @@ a document with an incorrect or missing file extension.
    problems when attempting to open the file due to the loss of its file
    extension.
 
-When you double-click an archive to open it, you should see it in the **Archive Manager** application.
+When you double-click an archive to open it, you should see it in the *Archive Manager* application.
 
 |Opened archive|
 
@@ -425,10 +425,10 @@ and flac. We recommend using this and other tools to work with documents within
 Tails for as much of your workflow as possible.
 
 Tails 4 replaces MAT with MAT2, which is usable via the command line and via a
-context menu in the **Files** application (called ``nautilus`` on the command
+context menu in the *Files* application (called ``nautilus`` on the command
 line).
 
-You can use MAT2 via the **Files** application by browsing to **Places ▸
+You can use MAT2 via the *Files* application by browsing to **Places ▸
 (Your file's location)** and right-clicking on your file. In the context
 menu, select **Remove metadata**.
 
@@ -564,7 +564,7 @@ To open the *Export Device* on the *Secure Viewing Station*, follow these steps:
 4. Under "Partitions and Drives", select the *Export Device* and click
    **Unlock**.
 5. Enter your passphrase, which we recommend keeping in your own personal
-   password manager (e.g., on your smartphone), not on **KeePassXC**.
+   password manager (e.g., on your smartphone), not on *KeePassXC*.
 6. Under "Partitions and Drives", open the encrypted drive by clicking
    **Open**.
 
@@ -594,7 +594,7 @@ Decrypting and Preparing to Publish
 .. note::
 
    To decrypt a VeraCrypt drive on a Windows or Mac workstation, you need
-   to have the **VeraCrypt** software installed. If you are unsure if you have the
+   to have the *VeraCrypt* software installed. If you are unsure if you have the
    software installed or how to use it, ask your administrator, or see
    the `Freedom of the Press Foundation guide <https://freedom.press/training/encryption-toolkit-media-makers/veracrypt-guide/>`__
    for working with VeraCrypt.
@@ -604,7 +604,7 @@ To access the *Export Device* on your everyday workstation, follow these steps:
 1. If your *Export Device* has a physical write protection switch, make sure it
    is in the *locked* position.
 2. Plug the *Export Device* into your everyday workstation.
-3. Launch the **VeraCrypt** application.
+3. Launch the *VeraCrypt* application.
 4. Click **Select Device** and select the *Export Device*, then click **OK**.
 5. Click **Mount**.
 6. Enter the passphrase for your *Export Device*. You should find this in your
@@ -615,7 +615,7 @@ To access the *Export Device* on your everyday workstation, follow these steps:
 As a security precaution, we recommend deleting the files on the *Export
 Device* after each copy operation. If you are using write protection, you have to perform this step on the *Secure Viewing Station* to get the security benefits of write protection.
 
-When you are done, switch back to the **VeraCrypt** window, and click **Dismount**.
+When you are done, switch back to the *VeraCrypt* window, and click **Dismount**.
 
 You are now ready to write articles and blog posts, edit video and
 audio, and begin publishing important, high-impact work!

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -53,8 +53,8 @@ computer, unless explicitly configured with an access token.
 
 To visit the *Journalist Interface*, click the *Journalist Interface* icon on
 the desktop. This will open Tor Browser to an ".onion" address. Log in with
-your username, passphrase, and two-factor authentication token, as
-shown in the first screenshot below. (If you have been provided with a YubiKey,
+your username, passphrase, and two-factor authentication token.
+(If you have been provided with a YubiKey,
 see :doc:`Using YubiKey with the Journalist Interface <yubikey_setup>` for
 detailed setup and usage information.)
 
@@ -62,6 +62,7 @@ detailed setup and usage information.)
 
 Reset Passphrase or Two-factor Authentication Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If necessary, journalists may reset their user passphrase or two-factor
 authentication token in their user profile. To navigate to your user profile,
 log in to the *Journalist Interface* and click on the link in the upper right
@@ -150,7 +151,7 @@ Step 1: Download the encrypted submission
 
 Documents and messages sent by sources can only be decrypted and viewed on the
 *Secure Viewing Station*. After clicking on an individual source, you will see
-the page below with any documents or messages the source has sent you. Documents
+a page with any documents or messages the source has sent you. Documents
 always end with ``-doc.gz.gpg``, while messages always end with ``-msg.gpg``.
 
 Click on a document or message name to save it, or select a number of documents
@@ -158,25 +159,24 @@ and save them all at once by clicking **Download Selected**.
 
 |Load external content|
 
-A dialog box with two choices will appear, **Cancel** and **Save file**:
+A dialog box with two choices will appear, **Cancel** and **Save file**.
 
 |Download selected|
 
-Click **Save file**. In the save dialog, select one
-of the two folders highlighted in red in the screenshot below:
+Click **Save file**. In the save dialog, select one of the two folders
+called **Tor Browser** and **Tor Browser (persistent)**.
+Note that the names may be abbreviated; you can view the full name by hovering
+the mouse over the shortcut.
 
 |Download to sandbox folder|
 
 The difference between these two folders is as follows:
 
-- **Tor Browser**. Downloads saved to this folder will be stored in memory,
+- **Tor Browser**: Downloads saved to this folder will be stored in memory,
   which means that they will only be available for the duration of your current
-  Tails session. In the screenshot, this is the currently selected folder.
-  The full path to this folder is ``/home/amnesia/Tor Browser``.
+  Tails session. The full path to this folder is ``/home/amnesia/Tor Browser``.
 
-- **Tor Browser (persistent)**: Note that the name may be abbreviated, as shown
-  in the screenshot; you can view the full name by hovering the mouse over the
-  shortcut. Downloads saved to this folder will be stored
+- **Tor Browser (persistent)**: Downloads saved to this folder will be stored
   on your Tails USB drive in the special persistent volume that is only
   available if you have unlocked it on the Tails welcome screen. The full path
   to this folder is ``/home/amnesia/Persistent/Tor Browser``.
@@ -213,7 +213,7 @@ device is known as your *Transfer Device*.
     accessible to you whenever you need it.
 
 You can right-click the file and select **Copy to**, then select the *Transfer
-Device*, as shown in the screenshots below.
+Device* in the **Select Copy Destination** dialog.
 
 |Copy to transfer device 1|
 
@@ -244,7 +244,7 @@ Click on the **Home** icon on your desktop, then on the *Transfer
 Device*. Copy the file into your **Persistent** folder. You can do so by
 opening a new window with the **Persistent** folder and dragging the file from
 one window to another. A faster method is to drag the file to the
-**Persistent** shortcut, as in the screenshot below:
+**Persistent** shortcut in the list of places.
 
 |Copy files to persistent|
 
@@ -256,14 +256,14 @@ one window to another. A faster method is to drag the file to the
 
 After successfully copying them to the *Secure Viewing Station*, erase the
 files from your *Transfer Device*. Ensure you're viewing the *Transfer Device* folder, then right click on the files that need removal and click "Wipe" to
-securely delete the files from your device:
+securely delete the files from your device.
 
 |Wiping documents|
 
 To decrypt and view documents or messages, return to your **Persistent** folder.
 All key actions are initiated by double-clicking:
 
-- Double-clicking archives in ZIP or gzip format will open the "Archive Manager"
+- Double-clicking archives in ZIP or gzip format will open the **Archive Manager**
   application (called ``file-roller`` on the command line), which allows you to extract the contents.
 
 - Double-clicking files that end in ``.gpg`` will attempt to decrypt the
@@ -281,7 +281,7 @@ a document with an incorrect or missing file extension.
 
 .. tip::
 
-   Always extract gzip archives with the "Archive Manager" application, which is
+   Always extract gzip archives with the **Archive Manager** application, which is
    the default when double-clicking the archive. Other methods may not preserve
    the filename contained in the archive.
 
@@ -292,7 +292,7 @@ a document with an incorrect or missing file extension.
    problems when attempting to open the file due to the loss of its file
    extension.
 
-When you double-click an archive to open it, you should see it in the "Archive Manager" application. It looks like this:
+When you double-click an archive to open it, you should see it in the **Archive Manager** application.
 
 |Opened archive|
 
@@ -564,7 +564,7 @@ To open the *Export Device* on the *Secure Viewing Station*, follow these steps:
 4. Under "Partitions and Drives", select the *Export Device* and click
    **Unlock**.
 5. Enter your passphrase, which we recommend keeping in your own personal
-   password manager (e.g., on your smartphone), not on KeePassXC.
+   password manager (e.g., on your smartphone), not on **KeePassXC**.
 6. Under "Partitions and Drives", open the encrypted drive by clicking
    **Open**.
 
@@ -594,7 +594,7 @@ Decrypting and Preparing to Publish
 .. note::
 
    To decrypt a VeraCrypt drive on a Windows or Mac workstation, you need
-   to have the VeraCrypt software installed. If you are unsure if you have the
+   to have the **VeraCrypt** software installed. If you are unsure if you have the
    software installed or how to use it, ask your administrator, or see
    the `Freedom of the Press Foundation guide <https://freedom.press/training/encryption-toolkit-media-makers/veracrypt-guide/>`__
    for working with VeraCrypt.
@@ -604,7 +604,7 @@ To access the *Export Device* on your everyday workstation, follow these steps:
 1. If your *Export Device* has a physical write protection switch, make sure it
    is in the *locked* position.
 2. Plug the *Export Device* into your everyday workstation.
-3. Launch the VeraCrypt application.
+3. Launch the **VeraCrypt** application.
 4. Click **Select Device** and select the *Export Device*, then click **OK**.
 5. Click **Mount**.
 6. Enter the passphrase for your *Export Device*. You should find this in your
@@ -615,7 +615,7 @@ To access the *Export Device* on your everyday workstation, follow these steps:
 As a security precaution, we recommend deleting the files on the *Export
 Device* after each copy operation. If you are using write protection, you have to perform this step on the *Secure Viewing Station* to get the security benefits of write protection.
 
-When you are done, switch back to the VeraCrypt window, and click **Dismount**.
+When you are done, switch back to the **VeraCrypt** window, and click **Dismount**.
 
 You are now ready to write articles and blog posts, edit video and
 audio, and begin publishing important, high-impact work!
@@ -636,7 +636,7 @@ details are compromised.
 To delete sources, first select them in the list of all sources in the
 *Journalist Interface*, then click the **Delete** button. You will be
 given a choice to delete all messages and files for the selected sources, or to
-delete the source accounts:
+delete the source accounts.
 
 |Delete sources|
 
@@ -665,43 +665,66 @@ see a list of source messages (filenames end with ``-msg.gpg``), file submission
 ``--reply.gpg``).
 
 Select the source data you wish to delete, then click the **Delete** button.
-You will be prompted for confirmation:
+You will be prompted for confirmation.
 
 |Delete individual submissions|
 
 From the same page, you also have the option to delete the entire source
 account. To do so, click the button labeled **Delete Source Account** at the
-bottom of the page. You will be prompted for confirmation:
+bottom of the page. You will be prompted for confirmation.
 
 |Delete source account|
 
 .. |Journalist Interface Login| image:: images/manual/screenshots/journalist-index_with_text.png
+   :alt: Login page to access the journalist interface. It requires a username, passphrase and two-factor authentication token.
 .. |Journalist Interface| image:: images/manual/screenshots/journalist-index_javascript.png
+   :alt: Example home page displaying a list of sources who sent documents or messages.
 .. |Load external content| image:: images/manual/screenshots/journalist-clicks_on_source_and_selects_documents.png
+   :alt: Example source page displaying two files: a document and a message, both selected. A button 'Download Selected' is visible above the list of files.
 .. |Download selected| image:: images/manual/tbb_Document5.png
+   :alt: Dialog box asking for confirmation before saving a file.
 .. |Download to sandbox folder| image:: images/manual/tbb_Document6.png
+   :alt: Files application displaying the name of the file to be saved and a 'Save' button. Two shortcuts named 'Tor Browser' and 'Tor Browser (...' are visible in the list of places on the left.
 .. |Copy to transfer device 1| image:: images/manual/copy-to-transfer-device-1.png
+   :alt: Files application displaying the menu that opens after a right-click on a file. The 'Copy to...' entry is selected.
 .. |Copy to transfer device 2| image:: images/manual/copy-to-transfer-device-2.png
+   :alt: Dialog box that opens after selecting 'Copy to', the Transfer Device is selected in the list of places on the left.
 .. |Copy files to persistent| image:: images/manual/viewing1.png
+   :alt: Files application displaying the content of the Transfer Device. A file is being dragged over a shortcut named 'Persistent' in the list of places on the left.
 .. |Opened archive| image:: images/manual/tails-archive.png
-.. |Decrypting| image:: images/manual/viewing2.png
+   :alt: Archive Manager application displaying an archive and the 'Extract' button on the top left.
 .. |Decrypted documents| image:: images/manual/viewing3.png
+   :alt: Files application displaying a decrypted file next to its encrypted version.
 .. |Opened document| image:: images/manual/viewing4.png
+   :alt: Text editor displaying a decrypted message. The file that was double-clicked is visible below in the Files application.
 .. |Sent reply| image:: images/manual/screenshots/journalist-composes_reply.png
+   :alt: Example source page displaying a form with a 'Submit' button for the journalist to write a reply.
 .. |Delete sources| image:: images/manual/screenshots/journalist-delete_sources.png
+   :alt: Example source page after sources were selected and the 'Delete' button clicked. Two buttons are visible: 'Files and Messages' and 'Source Accounts'.
 .. |Delete individual submissions| image:: images/manual/screenshots/journalist-delete_submissions.png
+   :alt: Example source page displaying a dialog box that asks for confirmation before deleting the selected submissions.
 .. |Delete source account| image:: images/manual/screenshots/journalist-delete_source_account.png
+   :alt: Example source page displaying a dialog box that asks for confirmation before deleting the source account.
 
 .. |mat2 context menu| image:: images/manual/screenshots/mat2_context_menu.png
+   :alt: Files application displaying the menu that opens after a right-click on a file. The 'Remove metadata' entry is selected.
 .. |mat2 cleaned| image:: images/manual/screenshots/mat2_cleaned.png
+   :alt: Files application displaying a cleaned image file next to its original version.
 .. |mat2 cli show| image:: images/manual/screenshots/mat2_cli_show.png
+   :alt: Terminal application displaying the metadata of a file.
 
 .. |Wiping documents| image:: images/manual/viewing5.png
+   :alt: Files application displaying the menu that opens after a right-click on a file. The 'Wipe' entry is selected.
 .. |Journalist account profile| image:: images/manual/screenshots/journalist-edit_account_user.png
+   :alt: Example user profile page of a journalist. It displays forms to reset their passhrase and two-factor authentication.
 .. |Unlock VeraCrypt in Tails 1| image:: images/manual/unlock_veracrypt_in_tails_1.png
+   :alt: The Applications menu on the Tails desktop. The 'Unlock VeraCrypt Volumes' entry is selected.
 .. |Unlock VeraCrypt in Tails 2| image:: images/manual/unlock_veracrypt_in_tails_2.png
+   :alt: Dialog box called 'Unlock VeraCrypt Volumes'. It displays an 'Unlock' button next to a drive name.
 .. |Unlock VeraCrypt in Tails 3| image:: images/manual/unlock_veracrypt_in_tails_3.png
+   :alt: Dialog box asking for a passphrase to unlock a VeraCrypt volume. The 'Unlock VeraCrypt Volumes' dialog box can be seen underneath.
 .. |Unlock VeraCrypt in Tails 4| image:: images/manual/unlock_veracrypt_in_tails_4.png
+   :alt: Dialog box called 'Unlock VeraCrypt Volumes'. It displays an 'Open' button next to a drive name.
 .. |br| raw:: html
 
     <br>

--- a/docs/source.rst
+++ b/docs/source.rst
@@ -150,9 +150,9 @@ Making Your First Submission
 ----------------------------
 
 Open Tor Browser and navigate to the .onion address for the SecureDrop you wish
-to make a submission to. The page should look similar to the screenshot below,
-although it will probably have a logo specific to the organization you are
-submitting to:
+to make a submission to. The page will invite you to get started with your
+first submission or to log in. It should have a logo specific to the organization
+you are submitting to.
 
 |Source Interface with Javascript Disabled|
 
@@ -160,17 +160,18 @@ If this is the first time you're using Tor Browser, it's likely that you
 have JavaScript enabled and that the Tor Browser's security level is set
 to "Low". In this case, there will be a purple warning banner at the top of
 the page that encourages you to disable JavaScript and change the security
-level to "Safest":
+level to "Safest".
 
 |Source Interface Security Slider Warning|
 
 Click the **Security Level** link in the warning banner, and a message bubble
-will pop up explaining how to adjust this setting:
+will pop up explaining how to increase the security level to **Safest**.
 
 |Fix Javascript warning|
 
-Follow the instructions, and the security setting in Tor Browser should look
-similar to this screenshot:
+1. Click the shield icon in the toolbar
+2. Select **Advanced Security Settings**
+3. Select **Safest**
 
 |Security Slider|
 
@@ -183,9 +184,9 @@ similar to this screenshot:
    "Safest" during the entirety of the session in which you access an
    organization's SecureDrop instance.
 
-The SecureDrop page should now refresh automatically and look
-similar to the screenshot below. If this is the first time you are using
-SecureDrop, click the **Get Started** button.
+The SecureDrop page should now refresh automatically and stop displaying
+the warning. If this is the first time you are using SecureDrop,
+click the **Get Started** button.
 
 |Source Interface with Javascript Disabled|
 
@@ -194,6 +195,8 @@ generated for you. Note that your codename will not be the same as the codename
 shown in the image below. It is extremely important that you both remember this
 code and keep it secret. After submitting documents, you will need to provide
 this code to log back in and check for responses.
+
+|Memorizing your codename|
 
 The best way to protect your codename is to memorize it. If you cannot memorize
 it right away, we recommend writing it down and keeping it in a safe place at
@@ -206,8 +209,6 @@ it, you should destroy the written copy.
 Once you have generated a codename and put it somewhere safe, click
 **Submit Documents**.
 
-|Memorizing your codename|
-
 You will next be brought to the submission page, where you may
 upload a document, enter a message to send to journalists, or both. You
 can only submit one document at a time, so you may want to combine
@@ -217,9 +218,9 @@ limit, we recommend that you send a message to the journalist explaining
 this, so that they can set up another method for transferring the
 documents.
 
-When your submission is ready, click **Submit**.
-
 |Submit a document|
+
+When your submission is ready, click **Submit**.
 
 After clicking **Submit**, a confirmation page should appear, showing
 that your message and/or documents have been sent successfully. On this
@@ -229,16 +230,18 @@ messages.
 |Confirmation page|
 
 Once you are finished submitting documents, be certain you have saved your
-secret codename and then click the **Log out** button. You should see the
-screen below:
+secret codename and then click the **Log out** button.
+
+The final step to clearing your session is to restart Tor Browser for
+optimal security. After logging out, you should see a new page recommending
+you to click the **New Identity** button in the Tor Browser toolbar.
 
 |Logout|
 
-The final step to clearing your session is to restart Tor Browser for
-optimal security. You can either close the browser entirely or follow
-the instructions on the page: click on the "New Identity" button in the toolbar
-and then click **Yes** in the dialog box that appears to confirm you'd like to
-restart Tor Browser:
+You can either close the browser entirely or follow the instructions on the page:
+
+1. Click on the **New Identity** button in the Tor Browser toolbar
+2. Click **Yes** in the dialog box that appears to confirm you'd like to restart Tor Browser
 
 |Restart TBB|
 
@@ -265,28 +268,40 @@ correspondences you had with journalists.
 
 |Check for a reply|
 
-After you delete the message from the journalist, make sure you see the
-below message.
+After you delete the reply from the journalist, make sure you see the
+confirmation message: "Reply deleted".
 
 |Delete received messages|
 
 .. |Source Interface Security Slider Warning| image:: images/manual/securedrop-security-slider-warning.png
+   :alt: Warning banner: Your Tor Browser's Security Level is too low.
 .. |Security Slider| image:: images/manual/source-turn-slider-to-high.png
+   :alt: Advanced Security Settings in Tor Browser.
 .. |Fix Javascript warning| image:: images/manual/security-slider-high.png
+   :alt: Example home page displaying instructions to increase Tor Browser's Security Level.
 .. |Source Interface with Javascript Disabled|
   image:: images/manual/screenshots/source-index.png
+     :alt: Example home page of a SecureDrop instance.
 .. |Memorizing your codename|
   image:: images/manual/screenshots/source-generate.png
+     :alt: Example welcome page displaying a codename.
 .. |Submit a document|
   image:: images/manual/screenshots/source-submission_entered_text.png
+    :alt: Example submission page, where documents and messages can be submitted.
 .. |Confirmation page|
   image:: images/manual/screenshots/source-lookup.png
+    :alt: Example submission page, displaying a confirmation message after a submission was sent successfully.
 .. |Logout|
   image:: images/manual/screenshots/source-logout_new_identity.png
+   :alt: Page displaying instructions to clear your Tor Browser session by resetting your identity.
 .. |Restart TBB| image:: images/manual/restart-tor-browser.png
+   :alt: Dialog box asking for confirmation before Tor Browser is restarted.
 .. |Check for response|
   image:: images/manual/screenshots/source-enter-codename-in-login.png
+    :alt: Example login page asking you to enter your secret codename.
 .. |Check for a reply|
   image:: images/manual/screenshots/source-checks_for_reply.png
+    :alt: Example submission page, displaying a reply from a journalist.
 .. |Delete received messages|
   image:: images/manual/screenshots/source-deletes_reply.png
+    :alt: Example submission page, displaying a confirmation message after a reply was deleted.


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

Implements the approach proposed in #236 for the sections of the documentation that target end-users (sources, journalists, admins).

Instead of coming up with new ways of composing the text with the images, I've re-applied as much as possible the patterns that I've found achieved the purpose in other parts of the documentation.


~~Fixes~~ Contributes to fixing #236
Mitigates the impact of #234 
Contributes to fixing #70 

_Compatible with (but does not depend on, nor require) https://github.com/freedomofpress/securedrop-docs/pull/196_

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->

- [ ] Proof-read the paragraphs around each modification to ensure continuous reading of text and images makes sense.
- [ ] Do the same without displaying the images (e.g. delete the images locally).

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
 
_No special considerations come to mind for release._ 


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000