### PR TITLE
Remove docs-related LFS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ This repository is used to build the [public documentation](https://docs.secured
 
 ## Quickstart
 
-1. This repository stores binaries such as screenshots via LFS. If not already present, install `git-lfs` by following the [install guide](https://github.com/git-lfs/git-lfs/wiki/Installation). After installation, download the binaries with `git-lfs fetch && git-lfs checkout`.
-2. Create a virtual environment with `python3 -m venv .venv` or the tooling of your choice
-3. Activate your virtual environment (e.g., `source .venv/bin/activate`)
-4. Ensure you are using an up-to-date version of `pip` in the virtual environment (e.g., `pip install --upgrade pip`)
-5. Install the project requirements with `pip install --require-hashes -r requirements/requirements.txt`
-6. Run `make docs` to start a live build of the documentation at http://localhost:8000
-7. Edit RST files under the docs directory - your changes will be reflected in the live build
+1. Create a virtual environment with `python3 -m venv .venv` or the tooling of your choice
+2. Activate your virtual environment (e.g., `source .venv/bin/activate`)
+3. Ensure you are using an up-to-date version of `pip` in the virtual environment (e.g., `pip install --upgrade pip`)
+4. Install the project requirements with `pip install --require-hashes -r requirements/requirements.txt`
+5. Run `make docs` to start a live build of the documentation at http://localhost:8000
+6. Edit RST files under the docs directory - your changes will be reflected in the live build
 
 ## License
 

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -22,22 +22,16 @@ Updating Documentation
 
 To get started editing the docs:
 
-1. Enable LFS:
-
-   The SecureDrop docs repository stores binaries such as screenshots via
-   Git Large File Storage (LFS). If not already present, install Git LFS
-   by following the `install guide <https://github.com/git-lfs/git-lfs/wiki/Installation>`_.
-
 .. _clone_the_rep:
 
-2. Clone the SecureDrop documentation repository:
+#. Clone the SecureDrop documentation repository:
 
    .. code:: sh
 
       git clone https://github.com/freedomofpress/securedrop-docs.git
 
 
-3. Install the dependencies:
+#. Install the dependencies:
 
    .. include:: ../includes/virtualenv.txt
 
@@ -46,9 +40,9 @@ To get started editing the docs:
       pip install --require-hashes -r requirements/requirements.txt
 
 
-.. _build_the_docs:
+   .. _build_the_docs:
 
-4. Build the docs for viewing in your web browser:
+#. Build the docs for viewing in your web browser:
 
    .. code:: sh
 
@@ -95,13 +89,6 @@ As a maintainer, you can push directly to a contributor fork, as long as there
 is an active Pull Request corresponding to the branch you are pushing to, and
 you have added the contributor remote with authentication enabled (i.e. the ``url``
 value in ``.git/config`` starts with ``git@github.com``).
-
-In addition, to avoid encountering a permission error with LFS file locking,
-you have to disable lock verification for the contributor fork:
-
-.. code:: sh
-
-   git config 'lfs.https://github.com/<contributor>/securedrop-docs/info/lfs.locksverify' false
 
 .. _updating_screenshots:
 


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

Removes the LFS instructions that were related to contributing to the documentation. (There is a mention of LFS in the [Release Management](https://docs.securedrop.org/development/release_management.html?highlight=lfs) page, that is unrelated, as far as I can tell.)

Fixes #240
See also #239

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] Proof-read the instructions ot ensure they still make sense.

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->

_No special considerations for release come to mind._

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000