### PR TITLE
Remove inaccurate includes about signing key expiry

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -239,7 +239,6 @@ Migrating Using a V2+V3 or V3-Only Backup
       gpg: Good signature from "SecureDrop Release Signing Key <securedrop-release-key-2021@freedom.press>" [unknown]
 
 
-   .. include:: includes/release-key-transition.txt
    .. important::
       If you do not see the message above, signature verification has failed
       and you should **not** proceed with the installation. If this happens,
@@ -481,7 +480,6 @@ source accounts, and journalist accounts. To do so, follow the steps below:
       gpg:                using RSA key 2359E6538C0613E652955E6C188EDD3B7B22E6A3
       gpg: Good signature from "SecureDrop Release Signing Key <securedrop-release-key-2021@freedom.press>" [unknown]
 
-   .. include:: includes/release-key-transition.txt
    .. important::
        If you do not see the message above, signature verification has failed
        and you should **not** proceed with the installation. If this happens,

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -83,8 +83,6 @@ command:
    gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
 
-.. include:: includes/release-key-transition.txt
-
 If you are not copy-pasting this command, we recommend you double-check you have
 entered it correctly before pressing enter. GPG will implicitly verify that the
 fingerprint of the key received matches the argument passed.


### PR DESCRIPTION
## Status
Ready for review 

## Description of Changes

#241 did not remove the instructions noting that the old release key expired from some sections where they are no longer applicable, because they refer to the new (not-expired) release key. This PR fixes that.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000