### PR TITLE
Point to Ubuntu 20.04.3

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -39,7 +39,7 @@ Install Ubuntu
   exactly as there are some "gotchas" that may cause your SecureDrop setup to break.
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-20.04.2 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
+20.04.3 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media. You should use the *Admin
 Workstation* to download and verify the Ubuntu installation media.
 
@@ -51,7 +51,7 @@ Download the Ubuntu Installation Media
 The installation media and the files required to verify it are available on the
 `Ubuntu Releases page`_. You will need to download the following files:
 
-* `ubuntu-20.04.2-live-server-amd64.iso`_
+* `ubuntu-20.04.3-live-server-amd64.iso`_
 * `SHA256SUMS`_
 * `SHA256SUMS.gpg`_
 
@@ -66,14 +66,14 @@ Alternatively, you can use the command line:
 .. code:: sh
 
    cd ~/Persistent
-   torify curl -OOO https://releases.ubuntu.com/20.04.2/{ubuntu-20.04.2-live-server-amd64.iso,SHA256SUMS{,.gpg}}
+   torify curl -OOO https://releases.ubuntu.com/20.04.3/{ubuntu-20.04.3-live-server-amd64.iso,SHA256SUMS{,.gpg}}
 
 .. note:: Downloading Ubuntu on the *Admin Workstation* can take a while
    because Tails does everything over Tor, and Tor is typically slow relative
    to the speed of your upstream Internet connection.
 
 .. _Ubuntu Releases page: https://releases.ubuntu.com/
-.. _ubuntu-20.04.2-live-server-amd64.iso: https://releases.ubuntu.com/20.04/ubuntu-20.04.2-live-server-amd64.iso
+.. _ubuntu-20.04.3-live-server-amd64.iso: https://releases.ubuntu.com/20.04/ubuntu-20.04.3-live-server-amd64.iso
 .. _SHA256SUMS: https://releases.ubuntu.com/20.04/SHA256SUMS
 .. _SHA256SUMS.gpg: https://releases.ubuntu.com/20.04/SHA256SUMS.gpg
 
@@ -121,12 +121,12 @@ key") means that you are not ready to proceed. ::
 
 The next and final step is to verify the Ubuntu image. ::
 
-    sha256sum -c <(grep ubuntu-20.04.2-live-server-amd64.iso SHA256SUMS)
+    sha256sum -c <(grep ubuntu-20.04.3-live-server-amd64.iso SHA256SUMS)
 
 If the final verification step is successful, you should see the
 following output in your terminal. ::
 
-    ubuntu-20.04.2-live-server-amd64.iso: OK
+    ubuntu-20.04.3-live-server-amd64.iso: OK
 
 .. caution:: If you do not see the line above it is not safe to proceed with the
              installation. If this happens, please contact us at
@@ -154,7 +154,7 @@ rather than any listed partitions (e.g. ``/dev/sdb2``).
 If your USB is mapped to /dev/sdX and you are currently in the directory that
 contains the Ubuntu ISO, you would use dd like so: ::
 
-   sudo dd conv=fdatasync if=ubuntu-20.04.2-live-server-amd64.iso of=/dev/sdX
+   sudo dd conv=fdatasync if=ubuntu-20.04.3-live-server-amd64.iso of=/dev/sdX
 
 .. _install_ubuntu:
 


### PR DESCRIPTION
## Status

Ready for review

## Description

Ubuntu 20.04.3 was [released](https://lists.ubuntu.com/archives/ubuntu-announce/2021-August/000271.html) on August 26, and the links to Ubuntu 20.04.2 are no longer valid.

In addition to the docs update, we'll likely want to test a fresh install on Ubuntu 20.04.3 as part of the QA cycle for SecureDrop 2.10.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000