### PR TITLE
Fix YubiKey linkcheck issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -308,4 +308,5 @@ linkcheck_ignore = [
     r"https://github.com/freedomofpress/securedrop/tree/.*",
     r"https://docs.securedrop.org/?$",
     r"https://support-docs.securedrop.org/?$",
+    "https://support.yubico.com/hc/en-us/articles/360016614780-OATH-HOTP-Yubico-Best-Practices-Guide",
 ]

--- a/docs/yubikey_setup.rst
+++ b/docs/yubikey_setup.rst
@@ -62,7 +62,7 @@ Under **Configuration Slot**, click **Configuration Slot 1**.
           **Slot 2** instead of the one in **Slot 1**. See the
           `YubiKey manual`_ for more information.
 
-.. _`Yubikey manual`: https://support.yubico.com/hc/en-us/articles/360016614900-YubiKey-5-Series-Technical-Manual
+.. _`Yubikey manual`: https://docs.yubico.com/hardware/yubikey/yk-5/tech-manual/index.html
 
 In the section titled **OATH-HOTP parameters**, uncheck the box for
 **OATH Token Identifier (6 bytes)**. Leave the HOTP length at 6 digits.


### PR DESCRIPTION
- The linkcheck tool hits a 403 Cloudflare page on linkcheck runs,
  but it's accessible just fine via browsers. Seems like
  ignore-listing it is our best bet for now.

- The technical manual also 403s, and it includes a note redirecting
  to a new URL, which does not have that issue.

## Status

Ready for review
## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000