### PR TITLE
sketches coordinated response to a critical release blocker

### DIFF
--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -174,6 +174,17 @@ Pre-Release
      release, it's the release manager's responsibility to either fix it
      or find someone who can.
 
+   * You may, at your discretion, escalate a `"release blocker"
+     <https://github.com/freedomofpress/securedrop/labels/release%20blocker>`_
+     to "coordinated response" status.  In this case, you (or the person you
+     designate, such as the issue's reporter) should coordinate an
+     incident-response–style investigation and resolution of the bug, using
+     tools like Etherpad and Google Docs/Sheets to consolidate information in
+     real time and convening short sync-up meetings as often as needed.  After
+     a coordinated response, make sure that the findings gathered in these
+     venues are reported back out publicly (i.e., in the original GitHub issues)
+     for transparency and for future reference.
+
    * Backport release QA fixes merged into ``develop`` into the release
      branch using ``git cherry-pick -x <commit>`` to clearly indicate
      where the commit originated from.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In our [retrospective](https://github.com/freedomofpress/securedrop/wiki/Sprint-Planning-Meeting-2021-10-27) of the SecureDrop 2.1.0 release process, we discussed freedomofpress/securedrop#6137 as an example of a critical release blocker requiring an all-hands-on-deck coordinated response.  The addition proposed here sketches what such a response can look like—but deliberately does not prescribe what it *must* look like, in deference to the release manager.

## Testing

Considering this pull request as a proposal for the sake of debate:

1. Do we want to describe this kind of coordinated response in the release-management documentation?  Somewhere else?
2. Is this how we want to describe it?  Should we specify it more or less?
3. Are there other process considerations not captured here?
    - For example, should there be a `coordinated response` or `all hands on deck` label to indicate this status?

## Release 

No special considerations.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000