### PR TITLE
Remove inaccurate tip in inauspicious location

### DIFF
--- a/docs/configure_admin_workstation_post_install.rst
+++ b/docs/configure_admin_workstation_post_install.rst
@@ -42,11 +42,6 @@ collected from files in
 ``~/Persistent/securedrop/install_files/ansible-base`` and stored in
 ``~/Persistent/.securedrop/torrc_additions`` thereafter.
 
-.. tip:: Copy the files ``app-journalist-aths`` and ``app-source-ths`` to
-         the Transfer Device in preparation for setting up the Journalist
-         Workstation. Then you can use the ``securedrop-admin`` tool to configure
-         access for Journalists as well.
-
 In addition, the script creates desktop and menu shortcuts for the Source
 and *Journalist Interfaces*, directs Tails to install Ansible at the
 beginning of every session, and sets up SSH host aliases for the servers.


### PR DESCRIPTION
## Status
Ready for review 

## Description of Changes

Removes a tip that instructs admins to copy nonexistent (because v2) configuration files. I opted to not update it because this seems like a location that's prone to errors -- we have instructions for onboarding journalists later, let's not duplicate them here.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000