### PR TITLE
Add link to preflight testing docs

### DIFF
--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -286,9 +286,8 @@ Release Process
 #. A reviewer must verify the build logs, obtain and sign the generated ``Release``
    file, and append the detached signature to the PR. The PR should remain in
    draft mode. The packages on ``apt-qa.freedom.press`` are now installable.
-#. Coordinate with one or more team members to confirm a successful
-   clean install in production VMs using the packages on
-   ``apt-qa.freedom.press``.
+#. Coordinate with one or more team members to `confirm a successful clean install in production VMs <https://github.com/freedomofpress/securedrop/wiki/QA-Procedures#preflight-testing>`__
+   using the packages on ``apt-qa.freedom.press``.
 #. If no issues are discovered in final QA, promote the packaging PR out of draft
    mode.
 #. A reviewer must merge the packaging PR. This will publish the packages on

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -286,7 +286,8 @@ Release Process
 #. A reviewer must verify the build logs, obtain and sign the generated ``Release``
    file, and append the detached signature to the PR. The PR should remain in
    draft mode. The packages on ``apt-qa.freedom.press`` are now installable.
-#. Coordinate with one or more team members to `confirm a successful clean install in production VMs <https://github.com/freedomofpress/securedrop/wiki/QA-Procedures#preflight-testing>`__
+#. Coordinate with one or more team members to `confirm a successful clean install in production VMs
+   <https://github.com/freedomofpress/securedrop/wiki/QA-Procedures#user-content-preflight-testing>`__
    using the packages on ``apt-qa.freedom.press``.
 #. If no issues are discovered in final QA, promote the packaging PR out of draft
    mode.


### PR DESCRIPTION

## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes
As requested in [0], we now have detailed docs in the SD wiki for
developers, and there's an obviously appropriate place to link out from
the RM docs, so here we are.

[0] https://github.com/freedomofpress/securedrop/wiki/QA-Procedures#preflight-testing


## Testing
Render locally and make sure the link works as expeted. 

## Release 
Dev-only.
