### PR TITLE
Fix inaccuracies in sample privacy policy

### DIFF
--- a/docs/deployment/sample_privacy_policy.rst
+++ b/docs/deployment/sample_privacy_policy.rst
@@ -27,13 +27,11 @@ Collection of Information From Sources
   message is automatically deleted.
 
 * Journalists decrypt and read each message offline. They are encouraged to
-  delete messages from the server on a regular basis. The date and time of any
-  message will be securely deleted from the server when the message is deleted.
+  delete messages from the server on a regular basis.
 
 * Please keep in mind that the actual messages you send and receive through
   SecureDrop may include personally identifying information. For this reason,
-  once you read a journalist’s message, we recommend you delete it. It will
-  then be securely deleted from the file system.
+  once you read a journalist’s message, we recommend you delete it.
 
 Also please note that when you submit certain types of files through SecureDrop,
 you may be sending us metadata associated with that file.


### PR DESCRIPTION
## Status
Ready for review 

## Description of Changes

1) The `last_updated` timestamp for sources is not removed or updated if a journalist deletes files or messages.

2) "Deleting" a reply as a source does not actually cause the file to be deleted. In fact, the Journalist Interface treats it as a  read receipt. (This is very counterintuitive behavior that we IMO should revise in future, but that's how it works right now.)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000