### PR TITLE
Update improvement.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -8,7 +8,7 @@ about: Suggest an improvement/change to the docs
 ## Describe the change
 <!-- A clear and concise description of what you want to happen)-->
 
-## How will this impact [SecureDrop users](https://github.com/freedomofpress/securedrop-ux/wiki#SecureDrop_Users)?
+## How will this impact [SecureDrop users](https://github.com/freedomofpress/securedrop-ux/wiki/Users)?
 <!-- how do you feel users might be impacted by this change—and specifically, which users? Has anecdotal feedback from users, directly, influenced this change? Does evidence exist from user research to support this idea? Could design or user research efforts be helpful to support a change? -->
 
 ## Additional context

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -8,14 +8,8 @@ about: Suggest an improvement/change to the docs
 ## Describe the change
 <!-- A clear and concise description of what you want to happen)-->
 
-
-## How will this impact users?
-
-
-## User Research Evidence
-
-<!-- Does evidence exist from user research to support this idea? Could research or design help validate or improve it? Has this idea been influenced by your conversations with users, or by your own experience as a SecureDrop user? If so, please note it here, and [take a look at our UX wiki](https://github.com/freedomofpress/securedrop-ux/wiki) for more information about our design and research efforts.-->
-
+## How will this impact [SecureDrop users]([https://github.com/freedomofpress/securedrop-ux/wiki#SecureDrop_Users which users])?
+<!-- how do you feel users might be impacted by this change—and specifically, which users? Has anecdotal feedback from users, directly, influenced this change? Does evidence exist from user research to support this idea? Could design or user research efforts be helpful to support a change? -->
 
 ## Additional context
 <!-- Add any other context or screenshots about the feature request here) -->

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -8,7 +8,7 @@ about: Suggest an improvement/change to the docs
 ## Describe the change
 <!-- A clear and concise description of what you want to happen)-->
 
-## How will this impact [SecureDrop users]([https://github.com/freedomofpress/securedrop-ux/wiki#SecureDrop_Users which users])?
+## How will this impact [SecureDrop users](https://github.com/freedomofpress/securedrop-ux/wiki#SecureDrop_Users)?
 <!-- how do you feel users might be impacted by this change—and specifically, which users? Has anecdotal feedback from users, directly, influenced this change? Does evidence exist from user research to support this idea? Could design or user research efforts be helpful to support a change? -->
 
 ## Additional context


### PR DESCRIPTION
1. "Has this idea been influenced by your conversations with users, or by your own experience as a SecureDrop user?" is not user research evidence. It's anecdotal feedback. Qualifying _anecdotal feedback_ as _user research evidence_ (the latter, aggregate information collected in a methodical fashion) is a disservice to the difference between the two. Anecdotal feedback is absolutely important, however—they just need to be correctly qualified.

2. Who the users are, needs to be more clearly spoken to in issues. Centering issues on existing user profiles (mini-personae) can be helpful.

2. In 3 years, I've not once produced any findings from user research to merit updates to the docs. As such, "User Research Evidence" as its own section is both moot and problematic.

## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review / Work in progress


## Description of Changes

* Description: 

* Fixes Issue#


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
*

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* 


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000