### PR TITLE
adds summary table of staging versus production virtual environments

### DIFF
--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -6,8 +6,13 @@ stack available in order to develop and test some features. To make this easier,
 the project includes a Vagrantfile that can be used to create two predefined 
 virtual environments:
 
-* :ref:`Staging <staging_vms>`
-* :ref:`Production <production_vms>`
++------------------------------------------------+-----------------------------------------------------+--------------------------------+----------------------------------------+
+| The...                                         | ...is provisioned via...                            | ...with packages from...       | ...and with Tails access configured... |
++================================================+=====================================================+================================+========================================+
+| :ref:`Staging environment <staging_vms>`       | host-level ``make staging``                         | host-level ``make build-debs`` | manually                               |
++------------------------------------------------+-----------------------------------------------------+--------------------------------+----------------------------------------+
+| :ref:`Production environment <production_vms>` | Tails-level ``securedrop-admin {sdconfig,install}`` | ``apt.freedom.press``          | via ``securedrop-admin tailsconfig``   |
++------------------------------------------------+-----------------------------------------------------+--------------------------------+----------------------------------------+
 
 This document explains the purpose of, and how to get started working with, each
 one.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In cfm/terraform-metal-securedrop-staging#3, I realized I'd gotten a bit confused between the staging- and production-grade [virtual environments](https://docs.securedrop.org/en/stable/development/virtual_environments.html) on account of how I was both using and tooling for them during the SecureDrop 2.1.0 QA cycle.  The change proposed here puts a summary table at the top of the "Virtual Environments" page to compare them so that their differences and possible uses are more readily apparent.

## Testing

Is the table correct?  Does it seem useful to you? clear?

## Release 

Relevant only during development and QA; no release considerations.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
    * No; will fix separately: #281
- [x] You have previewed (`make docs`) docs at http://localhost:8000