### PR TITLE
Fix typo in threat model mitigations page

### DIFF
--- a/docs/threat_model/mitigations.rst
+++ b/docs/threat_model/mitigations.rst
@@ -18,7 +18,7 @@ regional and political specificity.
 Application Code — SecureDrop Repository/Release
 ------------------------------------------------
 
-Attacks to the Application Code — SecureDrop Respository/Release
+Attacks to the Application Code — SecureDrop Repository/Release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -  Malicious code introduced in SecureDrop repository
 -  Malicious code introduced in SecureDrop release


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Description: While going through the projects documentation (great by the way) I found a small typo in threat model mitigations page.

* Fixes Issue#


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
*

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* 


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000