### PR TITLE
fixes typo in `apt-cache policy` command

### DIFF
--- a/docs/development/upgrade_testing.rst
+++ b/docs/development/upgrade_testing.rst
@@ -64,7 +64,7 @@ From the *Application Server*:
 
 .. code:: sh
 
-   apt-cache-policy securedrop-app-code
+   apt-cache policy securedrop-app-code
 
 The installed package version should match the latest stable version,
 but the locally built package with higher version should be available


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Fixes *tiny* (single-character!) typo encountered while testing freedomofpress/securedrop#6187.


## Testing

* [ ] Concur that `apt-cache-policy` is not a thing, while `apt-cache policy` is.

## Release 

No release considerations.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000