### PR TITLE
Fix minor typo in threat model

### DIFF
--- a/docs/threat_model/threat_model.rst
+++ b/docs/threat_model/threat_model.rst
@@ -12,7 +12,7 @@ to securedrop@freedom.press.
 Actors
 ------
 
-The SecureDrop ecosystem comprises a host of actors, organzed by the following high-level categories: :ref:`Users <users>`, :ref:`Adversaries <adversaries>`, and :ref:`Systems <systems>`.
+The SecureDrop ecosystem comprises a host of actors, organized by the following high-level categories: :ref:`Users <users>`, :ref:`Adversaries <adversaries>`, and :ref:`Systems <systems>`.
 
 .. _users:
 


### PR DESCRIPTION
`s/organzed/organized/`

I do not usually submit Pull Requests for single character changes, but happened to spot this typo while reading the documentation.