### PR TITLE
Fix Tails persistence links

### DIFF
--- a/docs/onboarding_admins.rst
+++ b/docs/onboarding_admins.rst
@@ -25,7 +25,7 @@ To onboard an additional administrator, you will need:
 
 To set up AW2, follow these steps:
 
-1. Boot AW1, `unlock its persistent volume <https://tails.boum.org/doc/first_steps/persistence/use/index.en.html>`__,
+1. Boot AW1, `unlock its persistent volume <https://tails.boum.org/doc/first_steps/persistence/index.en.html#use>`__,
    and `set an admin password on the welcome screen <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`__
 2. Ensure that Tails and the SecureDrop version on AW1 are up-to-date.
    If not, update now by following the :ref:`most recent upgrade guide <latest_upgrade_guide>`.

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -340,7 +340,7 @@ Workstation* was set up with `SSH Client Persistence`_, this key will be saved
 on the *Admin Workstation* and can be used in the future to authenticate to
 the servers in order to perform administrative tasks.
 
-.. _SSH Client Persistence: https://tails.boum.org/doc/first_steps/persistence/configure/index.en.html#index3h2
+.. _SSH Client Persistence: https://tails.boum.org/doc/first_steps/persistence/index.en.html#index12h2
 
 First, generate the new SSH keypair:
 


### PR DESCRIPTION
## Status

Ready for review
## Description of Changes

Tails docs have again been reorganized a bit, fixing broken links.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000