### PR TITLE
Document experimental podman support for dev setup

### DIFF
--- a/docs/development/setup_development.rst
+++ b/docs/development/setup_development.rst
@@ -39,6 +39,9 @@ be installed via the official documentation links:
 
 Make sure to follow the `post-installation steps for Linux`_.
 
+Experimental support for using `Podman`_ is available, set the ``USE_PODMAN=1``
+environment variable to enable it.
+
 
 Fedora Linux
 ~~~~~~~~~~~~
@@ -58,10 +61,14 @@ be installed via the official documentation link:
 
 Make sure to follow the `post-installation steps for Linux`_.
 
+Experimental support for using `Podman`_ is available, set the ``USE_PODMAN=1``
+environment variable to enable it.
+
 .. _`Docker CE for Ubuntu`: https://docs.docker.com/engine/install/ubuntu/
 .. _`Docker CE for Debian`: https://docs.docker.com/engine/install/debian/
 .. _`Docker CE for Fedora`: https://docs.docker.com/engine/install/fedora/
 .. _`post-installation steps for Linux`: https://docs.docker.com/engine/install/linux-postinstall/
+.. _`Podman`: https://podman.io/
 
 
 macOS


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Now that https://github.com/freedomofpress/securedrop/pull/6216 has been
merged, podman can be used instead of Docker by setting a `USE_PODMAN=1`
environment variable.

This only works for Linux setups for now and isn't super well tested
(yet!) to recommend it on the same level as Docker.

## Testing

`make docs` and look at the output

## Release 

No special considerations

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000