### PR TITLE
Update source.rst

### DIFF
--- a/docs/source.rst
+++ b/docs/source.rst
@@ -20,46 +20,40 @@ Source Guide
 What is SecureDrop?
 ---------------------------
 
-Dozens of news organizations — from *ProPublica* to *The New York Times* — use
-SecureDrop to accept tips securely and anonymously. You can reach out and share
-files, and messages, but for real anonymity, it’s important to take some extra
-precautions. This resource will describe things you can do to help protect your
-anonymity when using SecureDrop.
+SecureDrop is a tool that news organizations and NGOs use that enables secure and anonymous communication between whistleblowers and journalists. No personal information is collected; SecureDrop's servers are encrypted, and SecureDrop is not a “cloud” service. If you don’t have sensitive information to send to a news organization, it may be okay to use a traditional computer when reaching out. 
 
-Before moving ahead, note that your Internet Service Provider, or ISP (e.g.,
-Comcast), may already have a record of your visit to this website,
-docs.securedrop.org. Likewise, any related activity should be conducted outside
-of your workplace; if you are reading this page on a workplace device or
-network, they may also have a record of that.
+SecureDrop can accept both messages and individual file uploads (up to 500mb). If you have multiple files to submit, you may do that As a source, you can also return to receive follow-up correspondence with an organization, or to send additional information. Dozens of news organizations — from *ProPublica* to *The New York Times* — use SecureDrop to accept tips securely and anonymously.
 
-Here are some things you can do to further minimize risk.
+To truly protect your anonymity, it is important for you to take some extra precautions in advance. This resource will describe things you can do to help protect your anonymity when using SecureDrop. Note that your Internet Service Provider, or ISP (e.g., Comcast, Cox, Xfinity, Wave, etc), may already have a record of your visit to this website, docs.securedrop.org. 
+
+**Before you begin...**
+* DO NOT access SecureDrop on your employer's network.
+* DO NOT access SecureDrop using your employer's hardware.
+* DO NOT access SecureDrop on your home internet network.
+
+**DO** carefully read the reamining instructions, that will carefully step-through the reasons why we advise the above, and provide guidance to minimize risk when using SecureDrop.
+
+Suggested Devices for Using SecureDrop
+---------------------------
+When sensitive disclosures such as government improprieties are involved, we suggest you buy a new computer and at least one new USB flash drive. You should only use cash to make those purchases. 
+
+Many time-saving features of computers and phones can easily compromise your anonymity: bookmarks, recommendations, synchronization features, shortcuts to frequently opened files, etc. Those reasons and more are why using a dedicated computer for whistleblowing activities can be safer.
+
+To build an even stronger buffer for yourself, we recommend booting the computer into the `Tails operating system`_ (typically from a USB stick). Tails is specifically designed to run on your computer without leaving traces of your activity. This may take some additional technical steps, but it is safer and fairly simple to get started. Even if you choose to use a dedicated computer for SecureDrop that will never be used for anything else, Tails will help to avoid leaving traces of your activity on the computer's hard disk, in your ISP's logs, or on cloud services.
 
 
-Choosing the Right Location
+Choose the Right Location
 ---------------------------
 
-If you don’t have sensitive information to send to a news organization, it may
-be okay to use a traditional computer when reaching out. But when sensitive
-disclosures (e.g., national security) are involved, we suggest you buy a new
-computer and a USB flash drive, using cash. Either way, you should then find a
-busy cafe you don’t regularly go to and sit at a place with your back to a
-wall to avoid cameras capturing information on your screen or keystrokes.
+Find a busy cafe you don’t regularly go to and sit at a place with your back to a wall to avoid cameras capturing information on your screen or keystrokes. Be sure to also make any purchases while there (wifi, tea, snacks) or on your way to the cafe (bus, train, gas) with cash. 
 
-Get Tor Browser
+
+Use Tor Browser
 -------------------
 
-Each SecureDrop page is only available as an onion service, which is a
-special type of website with an address ending in ".onion" that is only
-accessible through Tor. Tor is an anonymizing network that makes it difficult
-for anybody observing the network to associate a user's identity (e.g., their
-computer's IP address) with their activity (e.g., uploading information to
-SecureDrop).
+Each SecureDrop may **only** be reached through the Tor Browser. SecureDrop pages are only available as onion services—encrypted web pages that end in ".onion," and only the Tor browser is able to open these pages. 
 
-The easiest and most secure way to use Tor is to download Tor Browser from
-the `Tor Project website`_. The Tor Browser is a modified version of the Firefox
-web browser. It was designed to protect your security and anonymity while
-using Tor. If there is a chance that downloading Tor Browser raises
-suspicion, you have a few alternatives, for example:
+Tor is an anonymizing network that makes it difficult for anybody observing the network to associate a user's identity (e.g., the computer's IP address) with their activity. Tor Browser can be downloaded from the `Tor Project's website`_. Tor Browser is a modified version of the Firefox web browser that also includes features protect your security and anonymity. If there is a chance that visiting the Tor Project's website to download Tor Browser might raise suspicion, you have a couple alternatives:
 
 * If your mail provider is less likely to be monitored, you can send a mail to
   gettor@torproject.org with the text "linux", "windows" or "osx" in the body
@@ -68,27 +62,9 @@ suspicion, you have a few alternatives, for example:
   `GitLab mirror <https://gitlab.com/thetorproject/gettorbrowser/tree/torbrowser-releases>`__.
   maintained by the Tor team.
 
-While using Tor Browser on your personal computer helps hide your activity
-on the network, it leaves traces of its own installation on your local
-machine. Your operating system may keep additional logs, for example, of the
-last time you used Tor Browser.
+While using Tor Browser on your personal computer helps hide your activity on the network, it will leave traces of its own installation on yourlocal
+machine. Most operating systems keep logs, for example, any time an application is used. The sensitivity of the information you share and the capabilities of those who may not want you to share that information, should be considered when making these decisions.
 
-In general, when you are trying to stay anonymous, many time-saving features of
-your computer or phone turn into threats: bookmarks, recommendations,
-synchronization features, shortcuts to frequently opened files, and so on. This
-is why using a dedicated computer for whistleblowing activities is generally safer.
-
-For greater deniability and security, we recommend booting the computer into the
-`Tails operating system`_ (typically from a USB stick). Tails is specifically
-designed to run on your computer without leaving traces of your activity or
-saving logs. It automatically routes all of your Internet browsing through Tor
-so you can easily access SecureDrop safely. This may take some additional
-technical steps, but it’s safer, and fairly simple to get started.
-
-Even if you are using a dedicated computer for your SecureDrop activity that you
-have never used and will never use for anything else, we recommend also using
-Tails to avoid leaving traces of your activity on the computer's hard disk, in
-your ISP's logs, or on cloud services.
 
 .. important::
 


### PR DESCRIPTION
Came to this page for some other reason, and saw that the section "What Is SecureDrop?" does not actually answer that question. It's an important UX best practice for content design and information architecture, to always answer a question if presented in a header, in the first paragraph (preferably the first sentence). So, I added some stuff from the Landing Page content we put through one round of user testing, at the top of this page. And then I kept going, but stopped at "Choose Who To Submit To."

Also:
- Eliminated use of the words "threats" and "deniability," as they feels too alarmist/alienating for end Source users (as does the term "state actors")
- Sought to eliminate frequent use of term "for example" and other passive-voiced text that detracts from content usability & desirability per UX best practices
- Moved "Choose who to submit to" above equipment suggestion, so Sources see that flag before mistakenly doing that research before getting their opsec on

## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review / Work in progress
NOTE: There's still some nitty things I'd like to edit, but I can't figure-out how to do that with the version I worked on, yesterday, lol. If folks generally like the direction of this, happy to invest the energy in doing as much.


## Description of Changes

* Description: 

* Fixes Issue#


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
*

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* 


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000