### PR TITLE
Do not use Django admin interface for Weblate announcements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -330,6 +330,7 @@ linkcheck_ignore = [
     r"http://127.0.0.1(:\d+)?/?",
     r"http://localhost(:\d+)?/?",
     "https://forum.securedrop.org/admin/users/list/active",
+    "https://weblate.securedrop.org/projects/securedrop/securedrop/#announcement",
     "https://weblate.securedrop.org/projects/securedrop/securedrop/#repository",
     "https://github.com/freedomofpress/securedrop-debian-packages-lfs",
     r"https://weblate.securedrop.org/accounts/profile/.*",

--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -537,7 +537,7 @@ with a release looming, the server can be rebooted.
 .. _`Weblate translation creation page`: https://weblate.securedrop.org/new-lang/securedrop/securedrop/
 .. _`Weblate desktop translation creation page`: https://weblate.securedrop.org/new-lang/securedrop/desktop/
 .. _`i18n timeline`: https://forum.securedrop.org/t/about-the-translations-category/16
-.. _`Weblate announcement`: https://weblate.securedrop.org/admin/trans/announcement
+.. _`Weblate announcement`: https://weblate.securedrop.org/projects/securedrop/securedrop/#announcement
 
 .. |Weblate commit Lock| image:: ../images/weblate/admin-lock.png
 .. |Weblate commit Locked| image:: ../images/weblate/admin-locked.png


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

As we have learned, creating an announcement via the Django admin
interface does not send out email notifications, regardless of whether the
"notify users" checkbox is ticked. Direct people to the in-Weblate form
that appears to actually send out notifications.

## Testing

Already tested by @mig5, https://github.com/freedomofpress/infrastructure/issues/3750#issuecomment-1034375109.

## Release 

No special considerations, developer facing docs.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000