### PR TITLE
Make it clear that docs are now self-hosted

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -127,7 +127,7 @@ recovery purposes), see :ref:`Migrating Using a Backup <migrating>`.
 For other data recovery scenarios, see
 :ref:`Additional Information <additional_restore_info>` or `contact Support`_.
 
-.. _contact Support: https://securedrop-support.readthedocs.io/en/latest/
+.. _contact Support: https://support-docs.securedrop.org/
 
 .. _restore_data:
 
@@ -415,7 +415,7 @@ process.
    **Wipe**. Then, reformat the device using the
    **Disks** utility.
 
-.. _contact Support: https://securedrop-support.readthedocs.io/en/latest/
+.. _contact Support: https://support-docs.securedrop.org/
 .. _an administration password: https://tails.boum.org/doc/first_steps/welcome_screen/administration_password
 
 .. _migrate_v2:
@@ -597,7 +597,7 @@ v3 onion services.
 If you require any assistance with migration or data recovery, please
 `contact Support`_.
 
-.. _contact Support: https://securedrop-support.readthedocs.io/en/latest/
+.. _contact Support: https://support-docs.securedrop.org/
 .. |br| raw:: html
 
     <br>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,10 +9,6 @@ import os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 
-# Detect if we're being built by Read the Docs
-# https://docs.readthedocs.io/en/latest/faq.html#how-do-i-change-behavior-when-building-with-read-the-docs
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -101,25 +97,20 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-if on_rtd:
-    html_theme = "default"
-else:
-    try:
-        # If you want to build the docs locally using the RTD theme,
-        # you may need to install it: ``pip install sphinx_rtd_theme``.
-        # https://github.com/snide/sphinx_rtd_theme#via-package
-        import sphinx_rtd_theme
+try:
+    # If you want to build the docs locally using the RTD theme,
+    # you may need to install it: ``pip install sphinx_rtd_theme``.
+    # https://github.com/snide/sphinx_rtd_theme#via-package
+    import sphinx_rtd_theme
 
-        html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-    except ImportError:
-        # This theme is included with Sphinx and is quite nice (based
-        # on the Pocoo themes), but since we're using the RTD theme
-        # for the production docs, it's best to use that to avoid
-        # issues due to discrepancies between the themes.
-        html_theme = "alabaster"
+    html_theme = "sphinx_rtd_theme"
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+except ImportError:
+    # This theme is included with Sphinx and is quite nice (based
+    # on the Pocoo themes), but since we're using the RTD theme
+    # for the production docs, it's best to use that to avoid
+    # issues due to discrepancies between the themes.
+    html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -2,17 +2,18 @@ Documentation Guidelines
 ========================
 
 SecureDrop's documentation is available at https://docs.securedrop.org. It is
-written in `reStructuredText`_ (reST),
-and is built by and hosted on `Read the Docs`_ (RTD). The documentation files
+written in `reStructuredText`_ (reST) and hosted by `Freedom of the Press Foundation`_
+using a theme by `Read the Docs`_. The documentation files
 are stored in the ``docs/`` directory of the `SecureDrop docs repository
 <https://github.com/freedomofpress/securedrop-docs>`_.
 
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _Freedom of the Press Foundation: https://freedom.press/
 .. _Read the Docs: https://docs.readthedocs.io/en/latest/index.html
 
 
-Integration with Read the Docs
-------------------------------
+Documentation versions
+----------------------
 
 .. include:: ../includes/docs-branches.txt
 
@@ -228,8 +229,8 @@ Capitalize all section headings in title case:
      Before You Begin
      ================
 
-     Read the Docs
-     -------------
+     Set up the Environment
+     ----------------------
 
   not
 
@@ -238,5 +239,5 @@ Capitalize all section headings in title case:
      Before you begin
      ================
 
-     Read the docs
-     -------------
+     Set up the environment
+     ----------------------

--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -320,9 +320,9 @@ Release Process
     in the format ``<major>.<minor>.<patch>-1``,  ``<major>.<minor>.<patch>-2``,
     and so on.
 
-#. Verify that the public documentation has been updated, by checking the
-   `ReadTheDocs build history <https://readthedocs.org/projects/securedrop/builds/>`_.
-   If necessary, restart the build.
+#. Verify that the public documentation has been updated. Inspecting or
+   restarting builds requires Codefresh access; if you lack access, a tech lead
+   or infra team member can do so on your behalf.
 #. Create a `release
    <https://github.com/freedomofpress/securedrop/releases>`_ on GitHub
    with a brief summary of the changes in this release.

--- a/docs/includes/docs-branches.txt
+++ b/docs/includes/docs-branches.txt
@@ -1,11 +1,10 @@
-.. note:: SecureDrop maintains two versions of documentation: `stable
+.. note:: SecureDrop maintains two documentation versions: `stable
           <https://docs.securedrop.org/en/stable/development/contributing.html>`_
           and `latest
           <https://docs.securedrop.org/en/latest/development/contributing.html>`_.
-          ``stable`` is the default used by our Read the Docs site, and is built
-          from our latest signed git tag. ``latest`` is built from the head of
-          the ``main`` git branch of the `securedrop-docs repository 
-          <https://github.com/freedomofpress/securedrop-docs>`_. 
+          ``stable`` is the default, and is built from our latest signed git tag.
+          ``latest`` is built from the head of the ``main`` git branch of the
+          `securedrop-docs repository <https://github.com/freedomofpress/securedrop-docs>`_.
           In almost all cases involving development work, you'll want to make
-          sure you have the ``latest`` version selected by using the menu in the 
-          bottom left corner of the Read the Docs site.
+          sure you have the ``latest`` version selected by using the menu in the
+          bottom left corner of the documentation site.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

- We no longer host the docs via RTD as of earlier this year
- Fixed links pointing to RTD instance of support docs (let's separately investigate if we can redirect those readthedocs builds so folks don't accidentally land there)

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000