### PR TITLE
Use direct SSH for prod VMs

### DIFF
--- a/docs/development/upgrade_testing.rst
+++ b/docs/development/upgrade_testing.rst
@@ -58,7 +58,7 @@ To confirm:
 
 .. code:: sh
 
-   molecule login -s libvirt-prod-focal -h app-prod
+   ssh app
 
 From the *Application Server*:
 
@@ -88,7 +88,7 @@ Then, log into the *Application Server*:
 
 .. code:: sh
 
-   molecule login -s libvirt-prod-focal -h app-prod
+   ssh app
    apt-cache policy securedrop-config
 
 The installed package version should match the latest stable version,


### PR DESCRIPTION


## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review 


## Description of Changes
In the upgrade testing docs, we were recommending ssh access on the VM
host, via molecule. That won't work, since prod VMs are fully firewalled
and drop all inbound. Instead, one should use the admin Tails VM, with
its custom SSH aliases configured by `./securedrop-admin tailsconfig`.

Encountered this during QA for 2.2.0. 

## Testing
Visual review is A-OK.

## Release
N/A, dev-only.