### PR TITLE
Add 2.1.0 to 2.2.0 upgrade guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/2.1.0_to_2.2.0.rst
    upgrade/2.0.2_to_2.1.0.rst
    upgrade/2.0.1_to_2.0.2.rst
    upgrade/2.0.0_to_2.0.1.rst

--- a/docs/upgrade/2.1.0_to_2.2.0.rst
+++ b/docs/upgrade/2.1.0_to_2.2.0.rst
@@ -1,12 +1,14 @@
-Upgrade from 2.0.2 to 2.1.0
+.. _latest_upgrade_guide:
+
+Upgrade from 2.1.0 to 2.2.0
 ===========================
 
-Updating Servers to SecureDrop 2.1.0
+Updating Servers to SecureDrop 2.2.0
 ------------------------------------
 Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop
 automatically within 24 hours of the release.
 
-Updating Workstations to SecureDrop 2.1.0
+Updating Workstations to SecureDrop 2.2.0
 -----------------------------------------
 
 .. note::
@@ -22,7 +24,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.1.0 by clicking "Update Now":
+Perform the update to 2.2.0 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -42,7 +44,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.1.0
+  git tag -v 2.2.0
 
 The output should include the following two lines: ::
 
@@ -54,9 +56,9 @@ Please verify that each character of the fingerprint above matches what is
 on the screen of your workstation. If it does, you can check out the
 new release: ::
 
-    git checkout 2.1.0
+    git checkout 2.2.0
 
-.. important:: If you do see the warning "refname '2.1.0' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.2.0' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 
@@ -79,6 +81,29 @@ operating system on your *Admin* and *Journalist Workstations*.
    upgrade prompt after connecting to the Internet, perform a
    :ref:`manual update <Update Tails Manually>`. If this also fails, please
    don't hesitate to contact us.
+
+Troubleshooting Kernel Issues
+-----------------------------
+SecureDrop 2.2.0 includes a kernel update on the *Application* and *Monitor
+Servers*, from version 5.4.136 to version 5.15.18. As with all kernel updates,
+we have extensively tested this update against
+:ref:`recommended hardware <Specific Hardware Recommendations>`.
+
+If you are running SecureDrop on hardware that is not officially supported, you
+may encounter compatibility issues with the new kernel. For example, the servers
+may not boot, or you may lose network connectivity. If this happens, you can
+temporarily downgrade to the previous kernel version.
+
+.. important::
+
+   To ensure continued secure operation of your SecureDrop instance, it is of
+   critical importance to resolve any compatibility issues with the new kernel
+   as quickly as possible. If you encounter problems with this update, please
+   get in touch with us urgently, so we can help you run the latest supported
+   kernel version.
+
+For information on how to downgrade to the previous kernel, and for additional
+troubleshooting information, please see our :doc:`Kernel Troubleshooting Guide <../kernel_troubleshooting>`.
 
 Getting Support
 ---------------


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Description: Add the 2.1.0 to 2.2.0 upgrade guide. Contents are mostly copied from the 2.0.2 to 2.1.0 version, with the Kernel part copied from the 2.0.1 to 2.0.2 version.

## Testing
* Read it :)

## Release 
* Should be coordinated with 2.2.0 release.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
  - it's hanging for me, I think it's on my end though
- [x] You have previewed (`make docs`) docs at http://localhost:8000