### PR TITLE
Add 2.2.1 upgrade guide; bump version

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -229,7 +229,7 @@ Migrating Using a V2+V3 or V3-Only Backup
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.2.0
+      git tag -v 2.2.1
 
    The output should include the following two lines:
 
@@ -250,10 +250,10 @@ Migrating Using a V2+V3 or V3-Only Backup
 
    .. code:: sh
 
-      git checkout 2.2.0
+      git checkout 2.2.1
 
    .. important::
-      If you see the warning ``refname '2.2.0' is ambiguous`` in the
+      If you see the warning ``refname '2.2.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
@@ -471,7 +471,7 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.2.0
+      git tag -v 2.2.1
 
    The output should include the following two lines:
 
@@ -490,11 +490,11 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
    .. code:: sh
 
-      git checkout 2.2.0
+      git checkout 2.2.1
 
 
    .. important::
-      If you see the warning ``refname '2.2.0' is ambiguous`` in the
+      If you see the warning ``refname '2.2.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.2.0"
+version = "2.2.1"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/2.2.0_to_2.2.1.rst
    upgrade/2.1.0_to_2.2.0.rst
    upgrade/2.0.2_to_2.1.0.rst
    upgrade/2.0.1_to_2.0.2.rst

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -137,7 +137,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.2.0
+    git tag -v 2.2.1
 
 The output should include the following two lines:
 
@@ -158,9 +158,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.2.0
+    git checkout 2.2.1
 
-.. important:: If you see the warning ``refname '2.2.0' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.2.1' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/upgrade/2.2.0_to_2.2.1.rst
+++ b/docs/upgrade/2.2.0_to_2.2.1.rst
@@ -1,12 +1,14 @@
-Upgrade from 2.1.0 to 2.2.0
+.. _latest_upgrade_guide:
+
+Upgrade from 2.2.0 to 2.2.1
 ===========================
 
-Updating Servers to SecureDrop 2.2.0
+Updating Servers to SecureDrop 2.2.1
 ------------------------------------
 Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop
 automatically within 24 hours of the release.
 
-Updating Workstations to SecureDrop 2.2.0
+Updating Workstations to SecureDrop 2.2.1
 -----------------------------------------
 
 .. note::
@@ -22,7 +24,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.2.0 by clicking "Update Now":
+Perform the update to 2.2.1 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -42,7 +44,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.2.0
+  git tag -v 2.2.1
 
 The output should include the following two lines: ::
 
@@ -54,9 +56,9 @@ Please verify that each character of the fingerprint above matches what is
 on the screen of your workstation. If it does, you can check out the
 new release: ::
 
-    git checkout 2.2.0
+    git checkout 2.2.1
 
-.. important:: If you do see the warning "refname '2.2.0' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.2.1' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 
@@ -90,8 +92,8 @@ continue to be supported.
 
 Troubleshooting Kernel Issues
 -----------------------------
-SecureDrop 2.2.0 includes a kernel update on the *Application* and *Monitor
-Servers*, from version 5.4.136 to version 5.15.18. As with all kernel updates,
+SecureDrop 2.2.1 includes a kernel update on the *Application* and *Monitor
+Servers*, from version 5.15.18 to version 5.15.26. As with all kernel updates,
 we have extensively tested this update against
 :ref:`recommended hardware <Specific Hardware Recommendations>`.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Standard upgrade guide with kernel notice

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000