### PR TITLE
Update instructions on how we manage Tor packages

### DIFF
--- a/docs/development/release_management.rst
+++ b/docs/development/release_management.rst
@@ -43,26 +43,6 @@ Pre-Release
    goal is to make sure we test against the lastest Tails release, including release candidates,
    so that we can report bugs early to Tails.
 
-#. Check the `Tor blog <https://blog.torproject.org/category/applications/>`_ for new release
-   candidates and new stable releases. Let the team know about any new release candidates during the
-   SecureDrop release process in case there are critical bug fixes. For a new stable release, file
-   an issue and upgrade Tor following these steps:
-
-      a. Bump the version in `fetch-tor-packages
-         <https://github.com/freedomofpress/securedrop/blob/develop/molecule/fetch-tor-packages/
-         playbook.yml>`_ and open a PR.
-
-      b. Run ``make fetch-tor-packages`` to download the new debs. The script uses
-         apt under the hood, so the Release file on the Tor packages is verified according
-         to Tor's signature, ensuring package integrity.
-
-      c. Copy the downloaded packages into the ``securedrop-dev-packages-lfs`` repo,
-         and open a PR so that a reviewer can verify that the checksums match the checksums
-         of the packages hosted on the
-         `Tor apt repo <https://deb.torproject.org/torproject.org/pool/main/>`_. Once the PR is
-         merged, the packages will be resigned with our an FPF-managed test-only signing key,
-         replacing the Tor signature, and served from ``apt-test.freedom.press``.
-
 #. Create a release branch.
 
    For a regular release, create a release branch off of ``develop``::
@@ -267,8 +247,6 @@ Release Process
 #. In your local branch, commit the built packages to the ``core/focal``
    directory.
 
-   * If the release includes a Tor update, make sure to include the
-     new Tor Debian packages.
    * If the release includes a kernel update, make sure to add the
      corresponding grsecurity-patched kernel packages, including both
      ``linux-image-*`` and ``linux-firmware-image-*`` packages as

--- a/docs/development/updating_tor.rst
+++ b/docs/development/updating_tor.rst
@@ -1,0 +1,36 @@
+Updating Tor
+============
+
+Given SecureDrop's significant reliance on Tor via Onion Services, we
+test new Tor versions to ensure they don't break SecureDrop before releasing
+them to users.
+
+Identifying new releases
+------------------------
+
+Announcements for new Tor releases are posted in the `Tor forum
+<https://forum.torproject.net/c/news/tor-release-announcement/28>`_.
+
+Our continuous integration automatically checks for new Tor packages every
+night and should commit them to the `securedrop-dev-packages-lfs
+<https://github.com/freedomofpress/securedrop-dev-packages-lfs>`_ repository.
+Within 15 minutes they should be available for download via
+``apt-test.freedom.press``.
+
+Testing
+-------
+
+Use a staging environment to verify that with the new Tor release, SecureDrop
+functions properly as an Onion Service, both the Source Interface and protected
+Journalist Interface.
+
+Then install the new Tor release on a production environment. Wait a day so
+it goes through the unattended-upgrades cycle, confirming that after the
+nightly reboot, Tor is still on the new version and running as expected.
+
+Promoting
+---------
+
+To promote a Tor release to production, copy the ``*.deb`` files over to the
+`securedrop-debian-packages-lfs <https://github.com/freedomofpress/securedrop-debian-packages-lfs>`_
+repository and follow those instructions.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -124,6 +124,7 @@ anonymous sources.
    development/portable_demo
    development/release_management
    development/dockerbuildmaint
+   development/updating_tor
 
 .. toctree::
   :caption: Threat Model


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Remove `fetch-tor-packages` from release management instructions,
  we are no longer tying it to releases, and the molecule playbook
  is obsolete and being removed.
* Add a new page that explains the CI process, what to test for new
  versions, and how to promote good releases.

Refs <https://github.com/freedomofpress/securedrop/issues/6233>.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* Read instructions, verify they make sense

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* No special considerations


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000