### PR TITLE
Added note about Ubuntu Advantage installer screen

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -273,6 +273,11 @@ servers:
 
 Select **Done** and press **Enter** to proceed.
 
+Ignore Enable Ubuntu Advantage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+On the **Enable Ubuntu Advantage** screen, choose **Done** to proceed without entering
+a token. The SecureDrop servers should not be registered with Ubuntu Advantage.
+
 Set up SSH access
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Status

Ready for review 


## Description of Changes

* As of 20.0.4.4, the Ubuntu installer now includes an Ubuntu Advantage setup screen - this PR includes a small change instructing users to ignore it.

* Fixes #321

## Testing

- [ ] CI passes
- [ ] changes look reasonable 

