### PR TITLE
Fix bullet syntax in Hardware's "Network Firewall" section

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -699,10 +699,11 @@ Network Firewall
 
 
 We currently recommend 2 network firewalls:
-* the `TekLager APU4D4 <https://teklager.se/en/products/routers/apu4d4-open-source-router>`__, running `OPNSense <https://opnsense.org/>`. It has 4 NICs and ports.
-* the `Netgate SG-3100
-<https://shop.netgate.com/products/3100-base-pfsense>`__ running `pfSense <https://www.pfsense.org/>`__. It has 3 NICs and an internal
-switch, increasing the number of available ports to 6.
+
+* the `TekLager APU4D4 <https://teklager.se/en/products/routers/apu4d4-open-source-router>`__, running `OPNSense <https://opnsense.org/>`__. It has 4 NICs and ports.
+* the `Netgate SG-3100 <https://shop.netgate.com/products/3100-base-pfsense>`__
+  running `pfSense <https://www.pfsense.org/>`__. It has 3 NICs and an internal
+  switch, increasing the number of available ports to 6.
 
 Network Switch
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Display the two firewalls as actual bullets
* Fix the OPNSense link

## Testing
* Visual review. Compare with https://docs.securedrop.org/en/latest/hardware.html#network-firewall

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000