### PR TITLE
Tails manual update URL changed

### DIFF
--- a/docs/update_tails_usbs.rst
+++ b/docs/update_tails_usbs.rst
@@ -86,7 +86,7 @@ Plug your *primary Tails USB* into the airgapped computer and boot into Tails.
 
 You can then perform the `manual update steps`_.
 
-.. _manual update steps: https://tails.boum.org/upgrade/clone-overview/index.en.html
+.. _manual update steps: https://tails.boum.org/upgrade/clone/index.en.html
 
 
 If you encounter issues


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Noticed the `make docs-linkcheck` failed because of the Tails manual update URL, this replaces it with the new one they use. (The sites contents are essentially the same, verified with the Wayback Machine)

## Checklist

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000