### PR TITLE
Tick "Enable interface" checkbox when setting up OPNSense interfaces

### DIFF
--- a/docs/firewall_opnsense.rst
+++ b/docs/firewall_opnsense.rst
@@ -449,7 +449,7 @@ Scroll down and click **Save**, then click **Apply changes** when prompted.
 Configure the OPT1 interface
 '''''''''''''''''''''''''''''
 Next, navigate to **Interfaces > [OPT1]**. In the **Basic configuration** section,
-check the checkbox labeled **Prevent interface removal**.
+check the checkboxes labeled **Enable interface** and **Prevent interface removal**.
 
 In the **Generic configuration** section, select ``Static IPv4`` in the **IPv4
 Configuration Type** dropdown, and ``None`` in the **IPV6 Configuration Type**
@@ -464,7 +464,7 @@ Click **Save**, then click **Apply changes** when prompted.
 Configure the OPT2 interface
 '''''''''''''''''''''''''''''
 Finally, navigate to **Interfaces > [OPT2]**. In the **Basic configuration** section,
-check the checkbox labeled **Prevent interface removal**.
+check the checkboxes labeled **Enable interface** and **Prevent interface removal**.
 
 In the **Generic configuration** section, select ``Static IPv4`` in the **IPv4
 Configuration Type** dropdown, and ``None`` in the **IPV6 Configuration Type**
@@ -794,4 +794,3 @@ to the `OPNSense Blog RSS feed <https://opnsense.org/blog/rss>`__.
 .. |Tails Network Settings| image:: images/firewall/tails_network_settings.png
 .. |Tails Manual Network Settings| image:: images/firewall/tails-manual-network-with-highlights.png
 .. |4 NIC Admin Workstation Static IP Configuration| image:: images/firewall/four_nic_admin_workstation_static_ip_configuration.png
-


### PR DESCRIPTION


## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

You need to tick the "Enable interface" checkbox when setting up the OPNSense interfaces. It's straightforward to figure out on your own, but nice to explicitly spell out.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* Open OPNSense firewall web UI and see that there are "Enable interface" checkboxes that you need to tick.

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000