### PR TITLE
Provide clearer instructions on how to open "Passwords and Keys"

### DIFF
--- a/docs/generate_submission_key.rst
+++ b/docs/generate_submission_key.rst
@@ -56,10 +56,10 @@ Create the Key
 Export the *Submission Public Key*
 ----------------------------------
 
-To manage GPG keys using the graphical interface (a program called "Passwords
-and Keys"), click the clipboard icon |gpgApplet| in the top right corner and
-select "Manage Keys". Click "GnuPG keys" and you should see the key that you just
-generated.
+Navigate to **Applications ▸ Utilities ▸ Passwords and Keys** to open a
+graphical interface to manage GPG keys. Click the clipboard icon |gpgApplet|
+in the top right corner and select "Manage Keys". Click "GnuPG keys" and you
+should see the key that you just generated.
 
 |My Keys|
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Provide clearer instructions on how to open "Passwords and Keys" by showing the breadcrumbs of the menus to go through to get it to open.


## Testing
* Navigate through those menus in Tails

## Release 
* n/a


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000