### PR TITLE
v2.4.0 Localization Manager updates

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -456,7 +456,6 @@ Then, post-release, either same day or day-after, the localization manager shoul
 * Remove the `Weblate announcement`_ about this release's translation timeline
   (if you set an end-date on the original announcement, this may happen automatically)
 * Update the `i18n timeline`_ in the forum.
-* :ref:`merge_develop_to_weblate`, which will update the `Demo Instance <https://demo.securedrop.org/>`__
 
 Translator credits
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Removes the post-release instruction to merge `securedrop@develop` into `securedrop-i18n@i18n`, which:

1. is no longer required to update the demo server; and
2. happens anyway as part of the string-freeze procedure.

Happily, the remaining post-release steps are all Web-based (Weblate and Discourse), which streamlines the Localization Manager's release-day checklist to the minimum.

## Testing

- [ ] Change makes sense!

## Release 

No special considerations.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000