### PR TITLE
Update Kleopatra docs for Tails 5.1

### DIFF
--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -305,9 +305,9 @@ All key actions are initiated by double-clicking:
   the contents to the same directory. If you have configured a passphrase for your
   *Submission Key*, you will be prompted for it.
 
-  On Tails 5, you must first launch Kleopatra (**Applications ▶ Accessories**)
-  and click the **Decrypt/Verify...** button. You will then be able to select
-  the file to decrypt it.
+  On Tails 5.1 or greater, double-clicking the ``.gpg`` file will launch
+  an application called **Kleopatra**, from which you can decrypt the file and
+  save the result to the same directory.
 
 - Double-clicking decrypted messages or documents will attempt to open them in a
   default application suitable for the file type.
@@ -338,9 +338,9 @@ When you double-click an archive to open it, you should see it in the *Archive M
 Click the **Extract** button to unpack the archive. Navigate to the folder
 containing the encrypted document message or document (ends with ``.gpg``).
 
-On Tails 4, double-click it to decrypt it. On Tails 5, open Kleopatra
-(**Applications ▶ Accessories**) and click **Decrypt/Verify**. Select the file
-in Kleopatra to decrypt it.
+Double-click the file to decrypt it. On Tails 5.1 or greater, this will launch
+**Kleopatra**, from which you can decrypt the file and save the result to the
+same directory.
 
 The decrypted file will have the same filename, but without ``.gpg`` at the end.
 

--- a/docs/upgrade/2.3.2_to_2.4.0.rst
+++ b/docs/upgrade/2.3.2_to_2.4.0.rst
@@ -79,28 +79,29 @@ until a fix is available (expected on May 31, 2022). If you are using Tor Browse
 for non-SecureDrop browsing, we recommend restarting Tor Browser before and after using it
 for SecureDrop.
 
-Upgrade to Tails 5.0
---------------------
+Upgrade from Tails 4 to Tails 5
+-------------------------------
 
-If you have not already done so, you must manually upgrade to Tails 5.0.
+If you have not already done so, you must manually upgrade from the Tails 4 release
+series to the Tails 5 series.
 
 .. important::
 
    You must upgrade your workstations to the latest version of SecureDrop by following
-   the steps above *before* upgrading to Tails 5.0. You can verify the version of SecureDrop
-   by running ``git status`` in your ``~/Persistent/securedrop`` directory. The
-   output should include "HEAD detached at 2.4.0".
+   the steps above *before* upgrading to the Tails 5 series. You can verify the version
+   of SecureDrop by running ``git status`` in your ``~/Persistent/securedrop`` directory.
+   The output should include "HEAD detached at 2.4.0".
 
-Tails 5.0 is the first version of Tails to be based on Debian 11 ("Bullseye").
-Among the most noticeable changes is the switch to a new frontend for GnuPG
-called Kleopatra. Once you upgrade your *Secure Viewing Station*, you will need
-to use Kleopatra to open ``.gpg`` files. Please see our :ref:`Journalist Guide <decrypting>`
+The Tails 5 series is based on Debian 11 ("Bullseye"). Among the most noticeable
+changes is the switch to a new frontend for GnuPG called Kleopatra. Once you
+upgrade your *Secure Viewing Station*, you will need to use Kleopatra to open
+``.gpg`` files. Please see our :ref:`Journalist Guide <decrypting>`
 for more information.
 
-You must perform the upgrade to Tails 5.0 manually. You need a blank USB drive
-that you can install Tails 5.0 USB on from scratch. You will use this drive
-to upgrade your *Journalist Workstation(s)*, your *Admin Workstation(s)*, and your
-*Secure Viewing Station(s)*.
+You must perform the upgrade to Tails 5 manually. You need a blank USB drive
+that you can install the latest release in the Tails 5 series on from scratch.
+You will use this drive to upgrade your *Journalist Workstation(s)*, your
+*Admin Workstation(s)*, and your *Secure Viewing Station(s)*.
 
 The persistent storage volumes of your USB drives will be migrated as part of
 this upgrade, but we still highly recommend backing them up first. Follow the


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Tails 5.1 includes a bugfix for this issue: https://gitlab.tails.boum.org/tails/tails/-/issues/18967

Therefore, we can reasonably remove the workaround instructions that are specific to Tails 5.0, but seems appropriate to still give folks a heads-up that the UX is a bit different.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000