### PR TITLE
Upgrade docs from 2.4.0 to 2.4.1

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -229,7 +229,7 @@ Migrating Using a V2+V3 or V3-Only Backup
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.4.0
+      git tag -v 2.4.1
 
    The output should include the following two lines:
 
@@ -250,10 +250,10 @@ Migrating Using a V2+V3 or V3-Only Backup
 
    .. code:: sh
 
-      git checkout 2.4.0
+      git checkout 2.4.1
 
    .. important::
-      If you see the warning ``refname '2.4.0' is ambiguous`` in the
+      If you see the warning ``refname '2.4.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
@@ -471,7 +471,7 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.4.0
+      git tag -v 2.4.1
 
    The output should include the following two lines:
 
@@ -490,11 +490,11 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
    .. code:: sh
 
-      git checkout 2.4.0
+      git checkout 2.4.1
 
 
    .. important::
-      If you see the warning ``refname '2.4.0' is ambiguous`` in the
+      If you see the warning ``refname '2.4.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.4.0"
+version = "2.4.1"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/2.4.0_to_2.4.1.rst
    upgrade/2.3.2_to_2.4.0.rst
    upgrade/2.3.1_to_2.3.2.rst
    upgrade/2.3.0_to_2.3.1.rst

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -137,7 +137,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.4.0
+    git tag -v 2.4.1
 
 The output should include the following two lines:
 
@@ -158,9 +158,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.4.0
+    git checkout 2.4.1
 
-.. important:: If you see the warning ``refname '2.4.0' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.4.1' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/upgrade/2.4.0_to_2.4.1.rst
+++ b/docs/upgrade/2.4.0_to_2.4.1.rst
@@ -63,8 +63,8 @@ Finally, run the following commands: ::
   ./securedrop-admin tailsconfig
 
 
-Enabling codename filtering
----------------------------
+Re-enabling codename filtering (if you previously disabled it)
+--------------------------------------------------------------
 This release fixes a bug in the feature to prevent initial messages
 containing the source's seven word secret codename. If you have
 previously disabled this feature, you can safely re-enable it in

--- a/docs/upgrade/2.4.0_to_2.4.1.rst
+++ b/docs/upgrade/2.4.0_to_2.4.1.rst
@@ -1,19 +1,15 @@
-Upgrade from 2.3.2 to 2.4.0
+.. _latest_upgrade_guide:
+
+Upgrade from 2.4.0 to 2.4.1
 ===========================
 
-Update Servers to SecureDrop 2.4.0
+Update Servers to SecureDrop 2.4.1
 ----------------------------------
 Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop
 automatically within 24 hours of the release.
 
-Update Workstations to SecureDrop 2.4.0
+Update Workstations to SecureDrop 2.4.1
 ---------------------------------------
-
-.. note::
-
-   If you encounter errors with the graphical updater, perform a
-   manual update. This will ensure that you have imported the new
-   `SecureDrop release signing key <https://media.securedrop.org/media/documents/signing-key-transition.txt>`_.
 
 Using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,7 +18,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.4.0 by clicking "Update Now":
+Perform the update to 2.4.1 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -42,7 +38,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.4.0
+  git tag -v 2.4.1
 
 The output should include the following two lines: ::
 
@@ -55,9 +51,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.4.0
+    git checkout 2.4.1
 
-.. important:: If you do see the warning "refname '2.4.0' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.4.1' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 
@@ -66,16 +62,14 @@ Finally, run the following commands: ::
   ./securedrop-admin setup
   ./securedrop-admin tailsconfig
 
-Tor Browser security issue
---------------------------
 
-Tails has `published an advisory <https://tails.boum.org/security/prototype_pollution/>`__
-for a serious security issue in Tor Browser affecting all versions of Tails. Administrators
-and journalists should disable JavaScript by `setting Tor Browser’s security level to “Safest”
-<https://tails.boum.org/doc/anonymous_internet/Tor_Browser/index.en.html#security-level>`__
-until a fix is available (expected on May 31, 2022). If you are using Tor Browser in Tails
-for non-SecureDrop browsing, we recommend restarting Tor Browser before and after using it
-for SecureDrop.
+Enabling codename filtering
+---------------------------
+This release fixes a bug in the feature to prevent initial messages
+containing the source's seven word secret codename. If you have
+previously disabled this feature, you can safely re-enable it in
+the :ref:`submission preferences <submission prefs>` section of the
+*Admin Interface*.
 
 Upgrade from Tails 4 to Tails 5
 -------------------------------
@@ -88,7 +82,7 @@ series to the Tails 5 series.
    You must upgrade your workstations to the latest version of SecureDrop by following
    the steps above *before* upgrading to the Tails 5 series. You can verify the version
    of SecureDrop by running ``git status`` in your ``~/Persistent/securedrop`` directory.
-   The output should include "HEAD detached at 2.4.0".
+   The output should include "HEAD detached at 2.4.1".
 
 The Tails 5 series is based on Debian 11 ("Bullseye"). Among the most noticeable
 changes is the switch to a new frontend for GnuPG called Kleopatra. Once you
@@ -123,24 +117,6 @@ steps to complete the upgrade:
 
 When prompted by Tails to "Install Only Once" or "Install Every Time", click
 **Install Every Time** (this is a change from previous versions of Tails).
-
-Language support changes
-------------------------
-
-We are pleased to announce support for Portuguese (Portugal). To enable this language,
-on the *Admin Workstation* run: ::
-
-  ./securedrop-admin sdconfig
-
-When prompted, add ``pt_PT`` to the list of locales. Then run: ::
-
-  ./securedrop-admin install
-
-We are currently lacking translators for Hindi and Romanian, which are both at risk
-of being removed in the next SecureDrop release. If you speak either language or know
-someone who does, please see our instructions on :ref:`contributing translations<Translations>`.
-
-.. include:: ../includes/backup-and-update-reminders.txt
 
 Getting Support
 ---------------


### PR DESCRIPTION
## Status
Ready for review; in draft mode until release object is live

## Description of Changes

- Standard patch-level release updates
- Tails 5 reminder
- Specific reminder that admins can safely re-enable codename filtering

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000