### PR TITLE
document workaround for DHCP collision in `bento/ubuntu-20.04` v202206.03.0

### DIFF
--- a/docs/development/virtual_environments.rst
+++ b/docs/development/virtual_environments.rst
@@ -214,11 +214,16 @@ Set the default Vagrant provider to ``libvirt``:
 
 Convert Vagrant boxes to libvirt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Convert the VirtualBox images for Focal from ``virtualbox`` to ``libvirt`` format:
+..
+   See also: securedrop#6497
+
+Convert the VirtualBox image for Focal from ``virtualbox`` to ``libvirt`` format.
+Pending resolution of an `upstream bug <https://github.com/chef/bento/issues/1421>`_,
+we must use an older version of this image.
 
 .. code:: sh
 
-   vagrant box add --provider virtualbox bento/ubuntu-20.04
+   vagrant box add --provider virtualbox bento/ubuntu-20.04 --box-version 202112.19.0
    vagrant mutate bento/ubuntu-20.04 libvirt
 
 You can now use the libvirt-backed VM images to develop against


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Bringing up the `app` and `prod` VMs will fail using `bento/ubuntu-20.04`
v202206.03.0 (freedomofpress/securedrop#6497), so here we pin to the
last-working v202111.19.0.

This can be reverted once chef/bento#1421 is resolved.


## Testing

* [ ] Changes look good on visual review.
* [x] *Optional:* Revised `vagrant box add` command correctly pulls the intended version.

## Release 

No special considerations; development-only.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000