### PR TITLE
Upgrade docs from 2.4.1 to 2.4.2

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -229,7 +229,7 @@ Migrating Using a V2+V3 or V3-Only Backup
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.4.1
+      git tag -v 2.4.2
 
    The output should include the following two lines:
 
@@ -250,10 +250,10 @@ Migrating Using a V2+V3 or V3-Only Backup
 
    .. code:: sh
 
-      git checkout 2.4.1
+      git checkout 2.4.2
 
    .. important::
-      If you see the warning ``refname '2.4.1' is ambiguous`` in the
+      If you see the warning ``refname '2.4.2' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
@@ -471,7 +471,7 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.4.1
+      git tag -v 2.4.2
 
    The output should include the following two lines:
 
@@ -490,11 +490,11 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
    .. code:: sh
 
-      git checkout 2.4.1
+      git checkout 2.4.2
 
 
    .. important::
-      If you see the warning ``refname '2.4.1' is ambiguous`` in the
+      If you see the warning ``refname '2.4.2' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.4.1"
+version = "2.4.2"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ anonymous sources.
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/2.4.1_to_2.4.2.rst
    upgrade/2.4.0_to_2.4.1.rst
    upgrade/2.3.2_to_2.4.0.rst
    upgrade/2.3.1_to_2.3.2.rst

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -137,7 +137,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.4.1
+    git tag -v 2.4.2
 
 The output should include the following two lines:
 
@@ -158,9 +158,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.4.1
+    git checkout 2.4.2
 
-.. important:: If you see the warning ``refname '2.4.1' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.4.2' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/upgrade/2.4.1_to_2.4.2.rst
+++ b/docs/upgrade/2.4.1_to_2.4.2.rst
@@ -1,12 +1,14 @@
-Upgrade from 2.4.0 to 2.4.1
+.. _latest_upgrade_guide:
+
+Upgrade from 2.4.1 to 2.4.2
 ===========================
 
-Update Servers to SecureDrop 2.4.1
+Update Servers to SecureDrop 2.4.2
 ----------------------------------
 Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop
 automatically within 24 hours of the release.
 
-Update Workstations to SecureDrop 2.4.1
+Update Workstations to SecureDrop 2.4.2
 ---------------------------------------
 
 Using the graphical updater
@@ -16,7 +18,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.4.1 by clicking "Update Now":
+Perform the update to 2.4.2 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -36,7 +38,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.4.1
+  git tag -v 2.4.2
 
 The output should include the following two lines: ::
 
@@ -49,9 +51,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.4.1
+    git checkout 2.4.2
 
-.. important:: If you do see the warning "refname '2.4.1' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.4.2' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 
@@ -60,14 +62,28 @@ Finally, run the following commands: ::
   ./securedrop-admin setup
   ./securedrop-admin tailsconfig
 
+Troubleshooting Kernel Issues
+-----------------------------
+SecureDrop 2.4.2 includes a kernel update on the *Application* and *Monitor
+Servers*, from version 5.15.26 to version 5.15.57. As with all kernel updates,
+we have extensively tested this update against
+:ref:`recommended hardware <Specific Hardware Recommendations>`.
 
-Re-enabling codename filtering (if you previously disabled it)
---------------------------------------------------------------
-This release fixes a bug in the feature to prevent initial messages
-containing the source's seven word secret codename. If you have
-previously disabled this feature, you can safely re-enable it in
-the :ref:`submission preferences <submission prefs>` section of the
-*Admin Interface*.
+If you are running SecureDrop on hardware that is not officially supported, you
+may encounter compatibility issues with the new kernel. For example, the servers
+may not boot, or you may lose network connectivity. If this happens, you can
+temporarily downgrade to the previous kernel version.
+
+.. important::
+
+   To ensure continued secure operation of your SecureDrop instance, it is of
+   critical importance to resolve any compatibility issues with the new kernel
+   as quickly as possible. If you encounter problems with this update, please
+   get in touch with us urgently, so we can help you run the latest supported
+   kernel version.
+
+For information on how to downgrade to the previous kernel, and for additional
+troubleshooting information, please see our :doc:`Kernel Troubleshooting Guide <../kernel_troubleshooting>`.
 
 Upgrade from Tails 4 to Tails 5
 -------------------------------
@@ -80,7 +96,7 @@ series to the Tails 5 series.
    You must upgrade your workstations to the latest version of SecureDrop by following
    the steps above *before* upgrading to the Tails 5 series. You can verify the version
    of SecureDrop by running ``git status`` in your ``~/Persistent/securedrop`` directory.
-   The output should include "HEAD detached at 2.4.1".
+   The output should include "HEAD detached at 2.4.2".
 
 The Tails 5 series is based on Debian 11 ("Bullseye"). Among the most noticeable
 changes is the switch to a new frontend for GnuPG called Kleopatra. Once you
@@ -123,3 +139,4 @@ Should you require further support with your SecureDrop installation, we are
 happy to help!
 
 .. include:: ../includes/getting-support.txt
+


### PR DESCRIPTION
## Status
Ready for review; in draft mode until release object is live

Related to https://github.com/freedomofpress/securedrop/pull/6506

## Description of Changes

- Standard patch-level release updates
- Standard kernel troubleshooting guide
- Tails 5 reminder

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000