### PR TITLE
Add reminder to update current version to upgrade guidelines

### DIFF
--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -153,6 +153,12 @@ as an example. As part of updating the documentation for a release:
    to the :doc:`Kernel Troubleshooting Guide <../kernel_troubleshooting>`.
 6. If you are not also the release manager, check with them about any other
    pertinent release-specific instructions that should be included.
+7. Finally, ensure that mentions of the current version are up to date. You can use
+   the ``update_version.sh`` convenience script to do so.
+
+   **Example:** If you are adding a guide to upgrade to 2.4.2, you can run
+   ``./update_version.sh 2.4.2``, then verify that the version changes are pertinent
+   and save them.
 
 Style Guide
 -----------


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

Adds a mention of the `./update_version.sh` script to the guidelines that we use to write upgrade guides.

Tangentially related to #365 


## Testing

- [ ] Confirm that the command is spelled out correctly
- [ ] Please proof-read and style-read me :slightly_smiling_face: 

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* No special consideration for release.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000