### PR TITLE
Update PR template format to make it easier to link to issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,11 @@ Ready for review / Work in progress
 
 * Description: 
 
-* Fixes Issue#
+* Resolves #
+<!-- Add an issue number immediately after the # symbol to link to an existing issue report --> 
+
+* Related Issues
+<!-- List any other unresolved, but relevant issues that this PR addresses -->
 
 
 ## Testing


### PR DESCRIPTION
## Status
Ready for review / Work in progress

## Description of Changes

* Description: 
    * A quick change to the PR template that makes it easier for folks submitting a request to have it link directly to the issue it resolves, so that the issue can be properly referenced and closed out automatically after the branch is merged.
    * Added an additional line item for issues that are not directly resolved by a given PR, but are still related

## Testing

Nothing to really test since this is for the GitHub side of things.

## Release 

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000