### PR TITLE
Ensure CSS reference works across paths

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,7 +1,7 @@
 {% extends "!layout.html" %}
 
 {% block extrahead %}
-<link rel="stylesheet" href="_static/releases.css" type="text/css" />
+<link rel="stylesheet" href="{{pathto('_static/releases.css',1)}}" type="text/css" />
 {% endblock %}
 
 {% block extrabody %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

As @gonzalo-bulnes reported in https://github.com/freedomofpress/securedrop-dev-docs/pull/1#pullrequestreview-1091288950, the `releases.css` file is sometimes not loaded correctly. Upon investigation, it turns out that this is true for the mainline docs build. To confirm, open your developer console and load: https://docs.securedrop.org/en/stable/development/contributing.html

What's happening here is that we're loading from `_static` as a subpath, which works only for the documentation root but not for documentation in subpaths like `development/`. Sphinx [offers a `pathto` function](https://www.sphinx-doc.org/en/master/templating.html#pathto) for generating a path relative to the HTML file you are loading. (In production, `_static` sits at `https://docs.securedrop.org/en/[latest|stable]/_static/releases.css`, so we can't just use `/_static`.)
## Test plan
- Build the documentation locally
- [ ] Confirm that `releases.css` loads for documents in the root and for documents in subpaths like `/development`

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] You have previewed (`make docs`) docs at http://localhost:8000
