### PR TITLE
Use improved workaround for latex errors from dev docs repo

### DIFF
--- a/deploy/build
+++ b/deploy/build
@@ -14,12 +14,8 @@ do_build() {
     export SECUREDROP_DOCS_RELEASE="$2"
 
     make html
-    # Due to remote SVG includes not working (they didn't work on RTD either),
-    # the LaTeX build will pause and wait for the user to press enter. It will
-    # also exit with an error status. Because of this failure, the TOC will
-    # not be correctly generated on the first run, and we must do it twice.
-    yes '' | make latexpdf || :
-    yes '' | make latexpdf || :
+    # Remote-loaded SVGs will cause a build failure unless we use force-mode.
+    LATEXMKOPTS="-interaction=nonstopmode -f" make latexpdf || true
 
     mkdir -p build
     mv docs/_build "build/${2}"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Going over the dev docs repo for https://github.com/freedomofpress/securedrop-dev-docs/pull/3, I saw there was a better strategy for continuing past LaTeX errors. By using that here, we can run that target only once and hopefully cut down on build time.

## Testing

After a local build (you may want to tag it), run that image with `-p 127.0.0.1:5080:5080` and verify that everything is served locally.

## Release 

No special considerations.
