### PR TITLE
Landing Page Overhaul

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -24,17 +24,19 @@ the requirements below, then `send us a request using this form.
 There are several benefits to being included in the SecureDrop directory. The
 most significant benefit is that it will be easier for potential sources to
 find your SecureDrop instance. Additionally, being included in the directory
-makes you eligible for a short onion address. This improves the experience by
-turning a lengthy, non-descriptive address into one that is short and 
-memorable. For example, a long .onion address might look like: ::
+makes you eligible for `an onion 
+name. <https://securedrop.org/faq/getting-onion-name-your-securedrop/>`__
+This improves the experience by turning a lengthy, non-descriptive address
+into one that is short and memorable. For example, a long .onion address 
+might look like: ::
 
-    xp44cagis447k3lpb4wwhcqukix6cgqokbuys24vmxmbzmaq2gjvc2yd.onion
+    sdolvtfhatvsysc6l34d65ymdwxcujausv7k5jk4cy5ttzhjoi6fzvyd.onion
 
-whereas the short onion address might look like: ::
+whereas the shorter onion name might look like: ::
 
-     theguardian.securedrop.tor.onion
+    nyworld.securedrop.tor.onion
 
-If you wish to receive a short onion address, one can be provided during the
+If you wish to receive an onion name, one can be provided during the
 instance verification process. The format for short onion addresses is: ::
 
     organization.securedrop.tor.onion
@@ -175,10 +177,10 @@ If you have been provided a short onion name for your instance, this address
 will also need to be plain text, without a hyperlink. We recommend using the
 text below to provide maximum clarity: ::
 
-    The SecureDrop instance can be found by entering the following address
-     in Tor browser: <short onion address>
+    The SecureDrop instance can be found by entering the following address in
+    the desktop version of Tor Browser: <short onion name>
 
-    Alternately, you can access the instance in Tor browser via: <long onion address>
+    Alternately, you can access the instance by entering: <long onion address>
 
 
 .. warning:: This is a strict requirement for inclusion in

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -15,6 +15,38 @@ your organization.
           implement minimum security requirements is sure to be noticed, and
           could undermine trust, discouraging possible sources.
 
+SecureDrop `maintains a directory of instances that meet our strict guidelines.
+<https://securedrop.org/directory/>`__ If you would like to be considered for
+inclusion in this directory, make sure your landing page is in compliance with
+the requirements below, then `send us a request using this form.
+<https://securedrop.org/directory/submit/>`__
+
+There are several benefits to being included in the SecureDrop directory. The
+most significant benefit is that it will be easier for potential sources to
+find your SecureDrop instance. Additionally, being included in the directory
+makes you eligible for a short onion address. This improves the experience by
+turning a lengthy, non-descriptive address into one that is short and 
+memorable. For example, a long .onion address might look like: ::
+
+    xp44cagis447k3lpb4wwhcqukix6cgqokbuys24vmxmbzmaq2gjvc2yd.onion
+
+whereas the short onion address might look like: ::
+
+     theguardian.securedrop.tor.onion
+
+If you wish to receive a short onion address, one can be provided during the
+instance verification process. The format for short onion addresses is: ::
+
+    organization.securedrop.tor.onion
+
+where ``organization`` can be any name you request, within reason.
+
+Being included in the SecureDrop directory may make your instance more visible,
+which could result in an uptick of illegitimate (spam) submissions.
+If you notice an increase in spam after being included in the directory, please
+let us know and we can remove your instance from the directory.
+
+
 URL and Location
 ----------------
 
@@ -31,6 +63,9 @@ in Apache by the encapsulating these settings within a
 block, which can be defined similarly in nginx by using the
 `location {} <https://nginx.org/en/docs/http/ngx_http_core_module.html#location>`__
 directive.
+
+.. warning:: Except for rare extenuating circumstances, this is a requirement
+             for inclusion in the SecureDrop Directory
 
 HTTPS Only (No Mixed Content)
 -----------------------------
@@ -58,6 +93,9 @@ Consider submitting your domain to be included in the `Chrome HSTS
 preload list <https://hstspreload.org/>`__ if you can meet all
 of the requirements. This will tell web browsers that the site is only
 ever to be reached over HTTPS.
+
+.. warning:: This is a strict requirement for inclusion in
+             the SecureDrop Directory
 
 Perfect Forward Secrecy
 -----------------------
@@ -116,7 +154,11 @@ Incapsula, Amazon CloudFront, etc.) for the SecureDrop *Landing Page*. These
 services intercept requests between a potential source and the SecureDrop
 *Landing Page* and can be used to `track`_ or collect information on sources.
 
+.. warning:: This is a strict requirement for inclusion in
+             the SecureDrop Directory
+
 .. _`track`: https://github.com/Synzvato/decentraleyes/wiki/Frequently-Asked-Questions
+
 
 Do Not Hyperlink .onion Addresses
 ---------------------------------
@@ -128,6 +170,19 @@ SecureDrop-related behavior.
 
 Instead, we recommend including .onion addresses in plain text, without a
 hyperlink.
+
+If you have been provided a short onion name for your instance, this address
+will also need to be plain text, without a hyperlink. We recommend using the
+text below to provide maximum clarity: ::
+
+    The SecureDrop instance can be found by entering the following address
+     in Tor browser: <short onion address>
+
+    Alternately, you can access the instance in Tor browser via: <long onion address>
+
+
+.. warning:: This is a strict requirement for inclusion in
+             the SecureDrop Directory
 
 Avoid Direct Links to SecureDrop.org
 ------------------------------------
@@ -142,6 +197,9 @@ We suggest offering a reference to the SecureDrop Onion Service in
 plain text, without a hyperlink (as per the preceding section):
 
 **sdolvtfhatvsysc6l34d65ymdwxcujausv7k5jk4cy5ttzhjoi6fzvyd.onion**
+
+.. warning:: This is a strict requirement for inclusion in
+             the SecureDrop Directory
 
 Apply Security Headers
 ----------------------
@@ -171,6 +229,7 @@ If you use Apache, you can use these:
     Header set X-Permitted-Cross-Domain-Policies: master-only
     Header set Content-Security-Policy: "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';"
     Header set Referrer-Policy "no-referrer"
+    Header set Permissions-Policy "camera 'none'; display-capture 'none'; geolocation 'none'; microphone 'none'; payment 'none'; usb 'none';"
 
 If you intend to run nginx as your webserver instead, this will work:
 
@@ -186,6 +245,7 @@ If you intend to run nginx as your webserver instead, this will work:
     add_header X-Permitted-Cross-Domain-Policies master-only;
     add_header Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';";
     add_header Referrer-Policy "no-referrer";
+    add_header Permissions-Policy "camera 'none'; display-capture 'none'; geolocation 'none'; microphone 'none'; payment 'none'; usb 'none';";
 
 
 Additional Apache Configuration
@@ -248,6 +308,13 @@ use ``server_tokens off;`` so that the webserver doesn't leak extra information.
 If you use nginx, `you can follow this
 link <https://gist.github.com/mtigas/8601685>`__ and use the
 configuration example provided by ProPublica.
+
+.. warning:: Setting the ``Referrer-policy`` header to ``no-referrer`` is a
+             strict requirement for inclusion in the SecureDrop directory. 
+             Setting the remaining headers as described is strongly
+             recommended, but will be reviewed on a case-by-case basis
+             for inclusion in the directory and does not necessarily prevent
+             the instance from being included.
 
 Change detection monitoring for the web application configuration and *Landing Page* content
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Description: This PR makes significant changes to the landing page documentation by:
  * Explaining about the SecureDrop directory
  * Describing short onion addresses, and how to display them on a landing page
  * Explaining the submission process (instance verification request)
  * Marking the relevant, strictly enforced requirements for landing pages to be included in our directory
  * Adding `Permissions-Policy` headers to list of suggestions

* Resolves #184 , #210, and  #46 

* Related Issues
  * #37 (I couldn't find an elegant way to explain how to enable this in apache/nginx, but I mention it here as this would be the appropriate place for those changes as well)

## Testing

* These changes can be tested by building the branch according to the readme

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
