### PR TITLE
Update Ubuntu version to be aligned with the rest of the docs

### DIFF
--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -37,7 +37,7 @@ Install Ubuntu
 ---------------
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-20.04.4 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
+20.04.5 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media.
 
 You should have already performed this step while setting up the Tails USB


### PR DESCRIPTION
## Description of Changes

#378 missed one mention of an old version of Ubuntu Server, this PR brings it in line with the rest of the docs.

## Release 

This can/should be merged to the be included in the stable docs.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
