### PR TITLE
Rewrite old docs paths to new developer docs site

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -27,6 +27,7 @@ http {
             rewrite ^/$ /en/stable/ redirect;
             rewrite ^/_/downloads/en/stable/pdf/$ /en/stable/SecureDrop.pdf permanent;
             rewrite ^/_/downloads/en/latest/pdf/$ /en/latest/SecureDrop.pdf permanent;
+            rewrite ^/(.*)/(.*)/development/(.*)$ https://developers.securedrop.org/$1/latest/$3 permanent;
         }
 
         add_header X-Frame-Options "DENY" always;


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Adds a redirect for old dev docs paths to the new path on developers.securedrop.org.

* Resolves https://github.com/freedomofpress/infrastructure/issues/3972

* Related Issue: https://github.com/freedomofpress/securedrop-dev-docs/issues/20

## Testing

 * Build the image with `docker build -t docs:redirects -f deploy/Dockerfile .`
 * Run the container with  `docker run -p 127.0.0.1:5080:5080 docs:redirects`
 * Visit http://localhost:5080 in browser and make sure that http://localhost:5080/en/stable/development/release_management.html redirects to https://developers.securedrop.org/en/latest/release_management.html