### PR TITLE
Test build step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,23 @@ jobs:
             source .venv/bin/activate
             make docs-linkcheck
 
+  build:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build production deployment
+          command: |
+            apt-get update && apt-get install docker.io -y
+            docker build --build-arg GIT_BRANCH=${CIRCLE_BRANCH} -f deploy/Dockerfile .
+
 workflows:
   version: 2
   build:
     jobs:
+      - build
       - lint
 
   nightly:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,10 +1,11 @@
 # sha256 as of 2021-11-09
 FROM python:3.9-slim-bullseye@sha256:408de0cf1a057f5501ee6642ad24a4762738f63bacf09fb4c8d861669260b01e AS sphinx
 
+ARG GIT_BRANCH=main
 RUN apt-get -q update && apt-get -qy upgrade && apt-get -qy install git make latexmk texlive-latex-extra
 COPY ./ .
 RUN pip install -r requirements/requirements.txt
-RUN deploy/build
+RUN deploy/build $GIT_BRANCH
 
 # sha256 as of 2021-11-09
 FROM nginx:mainline-alpine@sha256:af466e4f12e3abe41fcfb59ca0573a3a5c640573b389d5287207a49d1324abd8

--- a/deploy/build
+++ b/deploy/build
@@ -6,7 +6,6 @@
 set -e
 
 
-latest_branch=main
 stable_tag=$(git tag --sort=version:refname | tail -1)
 
 do_build() {
@@ -22,4 +21,4 @@ do_build() {
 }
 
 do_build "$stable_tag" stable
-do_build "$latest_branch" latest
+do_build "$1" latest


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

CI now has a build job that will build the deployment docker image just as it does in the real deployment step. Instead of forcing it to always build "main", allow a different branch to be tested with `--build-arg GIT_BRANCH=...`.

This is the same as <https://github.com/freedomofpress/securedrop-dev-docs/commit/e81a90ddf07a98e494a589c1d08564f5f824c887>, where a change broke building of the PDF, causing deployment to fail.

## Testing
* [ ] CI passes

## Release 
* no considerations


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
