### PR TITLE
Clarify landing page content expectations

### DIFF
--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -5,9 +5,10 @@
 
 SecureDrop itself runs as a Tor Onion Service. Organizations also need to
 create a SecureDrop *Landing Page* that will:
-    * explain how SecureDrop works
-    * give sources instructions on how to access the Tor Onion Service
-    * disclose the risks of accessing the SecureDrop instance or submitting documents
+
+* explain how SecureDrop works
+* give sources instructions on how to access the Tor Onion Service
+* disclose the risks of accessing the SecureDrop instance or submitting documents
 
 We also recommend including a privacy policy (see our :ref:`Sample
 Privacy Policy`) describing what data is collected and how it will be used by

--- a/docs/deployment/landing_page.rst
+++ b/docs/deployment/landing_page.rst
@@ -4,9 +4,12 @@
 ==============
 
 SecureDrop itself runs as a Tor Onion Service. Organizations also need to
-create a SecureDrop *Landing Page* that will explain how SecureDrop works, give
-sources instructions on how to access the Tor Onion Service, and disclose the
-risks. We also recommend including a privacy policy (see our :ref:`Sample
+create a SecureDrop *Landing Page* that will:
+    * explain how SecureDrop works
+    * give sources instructions on how to access the Tor Onion Service
+    * disclose the risks of accessing the SecureDrop instance or submitting documents
+
+We also recommend including a privacy policy (see our :ref:`Sample
 Privacy Policy`) describing what data is collected and how it will be used by
 your organization.
 
@@ -15,10 +18,93 @@ your organization.
           implement minimum security requirements is sure to be noticed, and
           could undermine trust, discouraging possible sources.
 
+*Landing Page* Content Suggestions
+----------------------------------
+
+The content below presents sample text for the SecureDrop component of a news
+organization’s tips page. It does not account for any specific legal
+or organizational needs, but should provide guidance for any outlet getting
+started on crafting *Landing Page* language. Any tweaks to the sample content
+should be left to the legal and editorial discretion of the individual outlet,
+and should be viewed as essential to upholding source protection and transparency.
+
+----
+
+**What is SecureDrop?**
+
+SecureDrop is an anonymity tool for journalists and whistleblowers. As a source,
+you can use our SecureDrop installation to anonymously submit documents to our
+organization. Our journalists use SecureDrop to receive source materials and
+securely communicate with anonymous contacts.
+
+**What should I know before submitting material through SecureDrop?**
+
+To protect your anonymity when using SecureDrop, it is essential that you do
+not use a network or device that can easily be traced back to your real
+identity. Instead, use public wifi networks and devices you control.
+
+- Do NOT access SecureDrop on your employer’s network.
+
+- Do NOT access SecureDrop using your employer’s hardware.
+
+- Do NOT access SecureDrop on your home network.
+
+- DO access SecureDrop on a network not associated with you, like the wifi at a library or cafe.
+
+**Got it. How can I submit files and messages through SecureDrop?**
+
+Once you are connected to a public network at a cafe or library, download
+and install the desktop version of `Tor Browser <https://www.torproject.org/download/>`_.
+
+Launch Tor Browser. Visit our organization’s unique SecureDrop URL at
+**http://our-unique-URL.onion/**.
+Follow the instructions you find on our source page to
+send us materials and messages.
+
+When you make your first submission, you will receive a unique codename.
+Memorize it. If you write it down, be sure to destroy the copy as soon as
+you’ve committed it to memory. Use your codename to sign back in to
+our source page, check for responses from our journalists, and upload
+additional materials.
+
+**As a source, what else should I know?**
+
+No tool can absolutely guarantee your security or anonymity.
+The best way to protect your privacy and anonymity as a source
+is to adhere to best practices.
+
+You can use a separate computer you’ve designated specifically to handle
+the submission process.
+Or, you can use an alternate operating system like Tails,
+which boots from a USB stick and erases your activity at the end of every session.
+
+A file contains valuable `metadata <https://ssd.eff.org/en/module/why-metadata-matters>`_ about its source — when it was created
+and downloaded, what machine was involved, the machine’s owner, etc.
+You can scrub metadata from some files prior to submission using the Metadata
+Anonymization Toolkit featured in Tails.
+
+Your online behavior can be extremely revealing.
+Regularly monitoring our publication’s social media or website can potentially
+flag you as a source. Take great care to think about what your online behavior
+might reveal, and consider using Tor Browser to mitigate such monitoring.
+
+Our organization retains strict access control over our SecureDrop project.
+A select few journalists within our organization will have access to
+SecureDrop submissions. We control the servers that store your submissions,
+so no third party has direct access to the metadata or content of what you send us.
+
+Do not discuss leaking or whistleblowing, even with trusted contacts.
+
+----
+
+The SecureDrop Directory
+----------------------------------
+
 SecureDrop `maintains a directory of instances that meet our strict guidelines.
 <https://securedrop.org/directory/>`__ If you would like to be considered for
-inclusion in this directory, make sure your landing page is in compliance with
-the requirements below, then `send us a request using this form.
+inclusion in this directory, make sure your landing page features the necessary
+items from the sample above, and is in compliance with the technical
+requirements below, then `send us a request using this form.
 <https://securedrop.org/directory/submit/>`__
 
 There are several benefits to being included in the SecureDrop directory. The
@@ -411,80 +497,3 @@ You can do so using Tor Browser:
 .. _`Tor Project website`: https://www.torproject.org/
 .. _`Tor Browser security level`: https://tb-manual.torproject.org/security-settings/
 .. _`using a different Tor circuit`: https://tb-manual.torproject.org/managing-identities/
-
-*Landing Page* Content Suggestions
-----------------------------------
-
-The content below presents sample text for the SecureDrop component of a news
-organization’s tips page. It does not account for any specific legal
-or organizational needs, but should provide guidance for any outlet getting
-started on crafting *Landing Page* language. Any tweaks to the sample content
-should be left to the legal and editorial discretion of the individual outlet,
-and should be viewed as essential to upholding source protection and transparency.
-
-----
-
-**What is SecureDrop?**
-
-SecureDrop is an anonymity tool for journalists and whistleblowers. As a source,
-you can use our SecureDrop installation to anonymously submit documents to our
-organization. Our journalists use SecureDrop to receive source materials and
-securely communicate with anonymous contacts.
-
-**What should I know before submitting material through SecureDrop?**
-
-To protect your anonymity when using SecureDrop, it is essential that you do
-not use a network or device that can easily be traced back to your real
-identity. Instead, use public wifi networks and devices you control.
-
-- Do NOT access SecureDrop on your employer’s network.
-
-- Do NOT access SecureDrop using your employer’s hardware.
-
-- Do NOT access SecureDrop on your home network.
-
-- DO access SecureDrop on a network not associated with you, like the wifi at a library or cafe.
-
-**Got it. How can I submit files and messages through SecureDrop?**
-
-Once you are connected to a public network at a cafe or library, download
-and install the desktop version of `Tor Browser <https://www.torproject.org/download/>`_.
-
-Launch Tor Browser. Visit our organization’s unique SecureDrop URL at
-**http://our-unique-URL.onion/**.
-Follow the instructions you find on our source page to
-send us materials and messages.
-
-When you make your first submission, you will receive a unique codename.
-Memorize it. If you write it down, be sure to destroy the copy as soon as
-you’ve committed it to memory. Use your codename to sign back in to
-our source page, check for responses from our journalists, and upload
-additional materials.
-
-**As a source, what else should I know?**
-
-No tool can absolutely guarantee your security or anonymity.
-The best way to protect your privacy and anonymity as a source
-is to adhere to best practices.
-
-You can use a separate computer you’ve designated specifically to handle
-the submission process.
-Or, you can use an alternate operating system like Tails,
-which boots from a USB stick and erases your activity at the end of every session.
-
-A file contains valuable `metadata <https://ssd.eff.org/en/module/why-metadata-matters>`_ about its source — when it was created
-and downloaded, what machine was involved, the machine’s owner, etc.
-You can scrub metadata from some files prior to submission using the Metadata
-Anonymization Toolkit featured in Tails.
-
-Your online behavior can be extremely revealing.
-Regularly monitoring our publication’s social media or website can potentially
-flag you as a source. Take great care to think about what your online behavior
-might reveal, and consider using Tor Browser to mitigate such monitoring.
-
-Our organization retains strict access control over our SecureDrop project.
-A select few journalists within our organization will have access to
-SecureDrop submissions. We control the servers that store your submissions,
-so no third party has direct access to the metadata or content of what you send us.
-
-Do not discuss leaking or whistleblowing, even with trusted contacts.


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

* Description:

Although the technical requirements for the landing page were clear, some feedback I've received (and behavior I've noticed) from news organizations is that the expected copy itself was either unclear, or difficult to find due to its position at the bottom, below the technical requirements.

This change moves that sample content to the top, and clarifies expectations for landing page contents for inclusion in the directory.

## Testing

* Build docs according to README, then view the landing page docs in the browser.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
