### PR TITLE
Flesh out QR code warning; add note about use of electronic devices in viewing area

### DIFF
--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -569,9 +569,13 @@ are important steps you can take to protect yourself:
 
 .. warning::
 
-   For maximum safety, it is recommended that cell phones and personal 
-   electronic devices be left outside of the secure environment where the
-   *Secure Viewing Station* is used.
+   If you have not memorized the passphrases to unlock the USB drives
+   for the Secure Viewing Station or the Transfer Device, you may need
+   to access a password manager on your phone or laptop to do so. We
+   recommend switching any required electronic devices into airplane mode,
+   and securely storing any devices you do not need outside the environment
+   in which you access the Secure Viewing Station. This further mitigates
+   the risk of accidentally compromising the air-gap.
 
 Fully mitigating the risks of malware received via SecureDrop is beyond the
 scope of this documentation. If you have questions, you can contact us at

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -570,11 +570,11 @@ are important steps you can take to protect yourself:
 .. warning::
 
    If you have not memorized the passphrases to unlock the USB drives
-   for the Secure Viewing Station or the Transfer Device, you may need
+   for the *Secure Viewing Station* or the *Transfer Device*, you may need
    to access a password manager on your phone or laptop to do so. We
    recommend switching any required electronic devices into airplane mode,
    and securely storing any devices you do not need outside the environment
-   in which you access the Secure Viewing Station. This further mitigates
+   in which you access the *Secure Viewing Station*. This further mitigates
    the risk of accidentally compromising the air-gap.
 
 Fully mitigating the risks of malware received via SecureDrop is beyond the

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -367,17 +367,6 @@ submitted malware.
    many of which relate to these topics, and offers `digital security training <https://freedom.press/training/request-training/>`__
    for news organization staff.
 
-.. warning::
-
-   Do not scan any QR codes you receive as part of your submissions. Scanning
-   a QR code with an internet connected device (such as a smart phone) can
-   alert third-parties to your actions, reveal the identities of your sources,
-   and breach the air gap that is in place with the *Secure Viewing Station*.
-   For maximum safety, it is recommended that cell phones and personal 
-   electronic devices be left outside of the secure environment where the
-   *Secure Viewing Station* is used.
-
-
 Organizing submissions
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -556,11 +545,14 @@ are important steps you can take to protect yourself:
    device.**
 
    `QR codes can contain malicious links`_ that your device will automatically
-   visit.
+   visit. This can alert third-parties to your actions, reveal the identities
+   of your sources, and breach the air gap that is in place with the
+   *Secure Viewing Station*. 
+
    In general, be careful when opening any links provided in a SecureDrop
-   submission, as this can leak information to third parties. If you are unsure
-   if a link is safe to click, you should consult internally, or contact
-   Freedom of the Press Foundation for assistance.
+   submission. If you are unsure if a link is safe to click, you should
+   consult internally, or contact Freedom of the Press Foundation for
+   assistance.
    |br| |br|
 
 5. **Don't photograph submissions using your smartphone, and be careful with all
@@ -574,6 +566,12 @@ are important steps you can take to protect yourself:
    reveal sensitive information about your SecureDrop usage patterns
    (potentially including GPS coordinates) to anyone who gains access
    to the file.
+
+.. warning::
+
+   For maximum safety, it is recommended that cell phones and personal 
+   electronic devices be left outside of the secure environment where the
+   *Secure Viewing Station* is used.
 
 Fully mitigating the risks of malware received via SecureDrop is beyond the
 scope of this documentation. If you have questions, you can contact us at

--- a/docs/journalist.rst
+++ b/docs/journalist.rst
@@ -367,6 +367,17 @@ submitted malware.
    many of which relate to these topics, and offers `digital security training <https://freedom.press/training/request-training/>`__
    for news organization staff.
 
+.. warning::
+
+   Do not scan any QR codes you receive as part of your submissions. Scanning
+   a QR code with an internet connected device (such as a smart phone) can
+   alert third-parties to your actions, reveal the identities of your sources,
+   and breach the air gap that is in place with the *Secure Viewing Station*.
+   For maximum safety, it is recommended that cell phones and personal 
+   electronic devices be left outside of the secure environment where the
+   *Secure Viewing Station* is used.
+
+
 Organizing submissions
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Status

Ready for review 


## Description of Changes

* Description: This change adds a warning to the Journalist Guide, in the SVS section, to warn against scanning QR codes as described in [an earlier blog post](https://securedrop.org/news/security-advisory-do-not-scan-qr-codes-submitted-through-securedrop-connected-devices/). It also advises leaving any personal electronic devices outside of the secure area where the SVS is used.

## Testing
* Build according to the steps in the README and view the changes in the browser


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
