### PR TITLE
Add 2.5.1 upgrade docs

### DIFF
--- a/docs/backup_and_restore.rst
+++ b/docs/backup_and_restore.rst
@@ -229,7 +229,7 @@ Migrating Using a V2+V3 or V3-Only Backup
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.5.0
+      git tag -v 2.5.1
 
    The output should include the following two lines:
 
@@ -250,10 +250,10 @@ Migrating Using a V2+V3 or V3-Only Backup
 
    .. code:: sh
 
-      git checkout 2.5.0
+      git checkout 2.5.1
 
    .. important::
-      If you see the warning ``refname '2.5.0' is ambiguous`` in the
+      If you see the warning ``refname '2.5.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
@@ -471,7 +471,7 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.5.0
+      git tag -v 2.5.1
 
    The output should include the following two lines:
 
@@ -490,11 +490,11 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
    .. code:: sh
 
-      git checkout 2.5.0
+      git checkout 2.5.1
 
 
    .. important::
-      If you see the warning ``refname '2.5.0' is ambiguous`` in the
+      If you see the warning ``refname '2.5.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.5.0"
+version = "2.5.1"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,12 +91,12 @@ If you would like to contribute to SecureDrop, please see our
    :name: upgradetoc
    :maxdepth: 2
 
+   upgrade/2.5.0_to_2.5.1.rst
    upgrade/2.4.2_to_2.5.0.rst
    upgrade/2.4.1_to_2.4.2.rst
    upgrade/2.4.0_to_2.4.1.rst
    upgrade/2.3.2_to_2.4.0.rst
    upgrade/2.3.1_to_2.3.2.rst
-   upgrade/2.3.0_to_2.3.1.rst
 
 .. toctree::
   :caption: Threat Model

--- a/docs/set_up_admin_tails.rst
+++ b/docs/set_up_admin_tails.rst
@@ -137,7 +137,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.5.0
+    git tag -v 2.5.1
 
 The output should include the following two lines:
 
@@ -158,9 +158,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.5.0
+    git checkout 2.5.1
 
-.. important:: If you see the warning ``refname '2.5.0' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.5.1' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/upgrade/2.4.2_to_2.5.0.rst
+++ b/docs/upgrade/2.4.2_to_2.5.0.rst
@@ -1,5 +1,3 @@
-.. _latest_upgrade_guide:
-
 Upgrade from 2.4.2 to 2.5.0
 ===========================
 

--- a/docs/upgrade/2.5.0_to_2.5.1.rst
+++ b/docs/upgrade/2.5.0_to_2.5.1.rst
@@ -1,3 +1,5 @@
+.. _latest_upgrade_guide:
+
 Upgrade from 2.5.0 to 2.5.1
 ===========================
 

--- a/docs/upgrade/2.5.0_to_2.5.1.rst
+++ b/docs/upgrade/2.5.0_to_2.5.1.rst
@@ -1,12 +1,12 @@
-Upgrade from 2.3.0 to 2.3.1
+Upgrade from 2.5.0 to 2.5.1
 ===========================
 
-Update Servers to SecureDrop 2.3.1
+Update Servers to SecureDrop 2.5.1
 ----------------------------------
 Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop
 automatically within 24 hours of the release.
 
-Update Workstations to SecureDrop 2.3.1
+Update Workstations to SecureDrop 2.5.1
 ---------------------------------------
 
 .. note::
@@ -22,7 +22,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.3.1 by clicking "Update Now":
+Perform the update to 2.5.1 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -42,7 +42,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.3.1
+  git tag -v 2.5.1
 
 The output should include the following two lines: ::
 
@@ -55,9 +55,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.3.1
+    git checkout 2.5.1
 
-.. important:: If you do see the warning "refname '2.3.1' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.5.1' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 
@@ -71,15 +71,55 @@ Update Tails
 Follow the graphical prompts to update to the latest version of the Tails
 operating system on your *Admin* and *Journalist Workstations*.
 
-.. important ::
+If you have not already done so, you must manually upgrade from the Tails 4 release
+series to the Tails 5 series.
 
-   Older versions of Tails had problems with automatic updates, which SecureDrop
-   tries to correct automatically. Check the version of Tails on your *Admin* and
-   *Journalist Workstations* (**Applications ▸ Tails ▸ About Tails**). If you are
-   running a version older than Tails 4.23, and did not receive an automatic
-   upgrade prompt after connecting to the Internet, perform a
-   :ref:`manual update <Update Tails Manually>`. If this also fails, please
-   don't hesitate to contact us.
+Upgrade from Tails 4 to Tails 5
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. important::
+
+   You must upgrade your workstations to the latest version of SecureDrop by following
+   the steps above *before* upgrading to the Tails 5 series. You can verify the version
+   of SecureDrop by running ``git status`` in your ``~/Persistent/securedrop`` directory.
+   The output should include "HEAD detached at 2.5.1".
+
+The Tails 5 series is based on Debian 11 ("Bullseye"). Among the most noticeable
+changes is the switch to a new frontend for GnuPG called Kleopatra. Once you
+upgrade your *Secure Viewing Station*, you will need to use Kleopatra to open
+``.gpg`` files. Please see our :ref:`Journalist Guide <decrypting>`
+for more information.
+
+You must perform the upgrade to Tails 5 manually. You need a blank USB drive
+that you can install the latest release in the Tails 5 series on from scratch.
+You will use this drive to upgrade your *Journalist Workstation(s)*, your
+*Admin Workstation(s)*, and your *Secure Viewing Station(s)*.
+
+The persistent storage volumes of your USB drives will be migrated as part of
+this upgrade, but we still highly recommend backing them up first. Follow the
+steps for :ref:`updating Tails manually <Update Tails Manually>`.
+
+Fore each *Journalist* and *Admin Workstation*, perform the following additional
+steps to complete the upgrade:
+
+1. Boot the USB drive
+2. On the Tails welcome screen, unlock the persistent volume and configure an
+   administrator password
+3. Open a terminal (**Applications ▸ Utilities ▸ Terminal**)
+4. Run the following commands:
+
+::
+
+  cd ~/Persistent/securedrop/admin
+  rm -rf .venv3
+  cd ..
+  ./securedrop-admin setup
+
+When prompted by Tails to "Install Only Once" or "Install Every Time", click
+**Install Every Time** (this is a change from previous versions of Tails).
+
+.. include:: ../includes/backup-and-update-reminders.txt
+
 
 Getting Support
 ---------------


### PR DESCRIPTION
## Status

Draft mode til release train gets underway

## Description of Changes

* Add 2.5.1 upgrade guide and bump $current_version via `update_version`

## Testing
* Manual review + linting passes

## Release 
* See above 


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [:x:] Doc link linting (`make docs-linkcheck`) passed: No, error with `/home/user/projects/securedrop-docs/docs/set_up_transfer_and_export_device.rst:103:broken link: https://ssd.eff.org/en/module/creating-strong-passwords#1`, but not related to these changes 
- [x] You have previewed (`make docs`) docs at http://localhost:8000
