### PR TITLE
Add a dark theme

### DIFF
--- a/docs/_static/rtd_dark.css
+++ b/docs/_static/rtd_dark.css
@@ -1,0 +1,116 @@
+/*!
+ * @name          Readthedocs
+ * @namespace     http://userstyles.org
+ * @description	  Styles the documentation pages hosted on Readthedocs.io
+ * @author        Anthony Post
+ * @homepage      https://userstyles.org/styles/142968
+ * @version       0.20170529055029
+ *
+ * Modified by Aloïs Dreyfus: 20200527-1037
+ * Modified by Erik Kalkoken: 20220615
+ * Modified by Nathan Dyer: 20230103
+ */
+
+@media (prefers-color-scheme: dark) {
+
+	a {
+		color: #7dbdff;
+	}
+	a:visited {
+		color: #bf84d8;
+	}
+
+	pre {
+		background-color: #2d2d2d !important;
+	}
+
+	.wy-nav-content {
+		background: #3c3c3c;
+		color: aliceblue;
+	}
+
+	.method dt, .class dt, .data dt, .attribute dt, .function dt,
+	.descclassname, .descname {
+		background-color: #525252 !important;
+		color: white !important;
+	}
+
+	.toc-backref {
+		color: #333333 !important;
+	}
+
+	code.literal {
+		background-color: #2d2d2d !important;
+		border: 1px solid #333333 !important;
+	}
+
+	.wy-nav-content-wrap {
+		background-color: rgba(0, 0, 0, 0.7) !important;
+	}
+
+	.sidebar {
+		background-color: #191919 !important;
+	}
+
+	.sidebar-title {
+		background-color: #2b2b2b !important;
+	}
+
+	.xref, .py-meth {
+		color: #7ec3e6 !important;
+	}
+
+	.admonition, .note {
+		background-color: #2d2d2d !important;
+	}
+
+	.wy-side-nav-search {
+		background-color: inherit;
+		border-bottom: 1px solid #fcfcfc;
+	}
+
+	.wy-table thead, .rst-content table.docutils thead, .rst-content table.field-list thead {
+		background-color: #b9b9b9;
+	}
+
+	.wy-table thead th, .rst-content table.docutils thead th, .rst-content table.field-list thead th {
+		border: solid 2px #e1e4e5;
+	}
+
+	.wy-table thead p, .rst-content table.docutils thead p, .rst-content table.field-list thead p {
+		margin: 0;
+	}
+
+	.wy-table-odd td, .wy-table-striped tr:nth-child(2n-1) td, .rst-content table.docutils:not(.field-list) tr:nth-child(2n-1) td {
+		background-color: #343131;
+	}
+
+	.highlight .m {
+		color: inherit
+	}
+
+	.highlight .nv {
+		color: #7dbdff
+	}
+
+	body {
+		text-align: justify;
+	}
+
+	.rst-content .section .admonition ul {
+		margin-bottom: 0;
+	}
+
+	li.toctree-l1 {
+		margin-top: 5px;
+		margin-bottom: 5px;
+	}
+
+	.wy-menu-vertical li code {
+		color: #E74C3C;
+	}
+
+	.wy-menu-vertical .xref {
+		color: #529ecf !important;
+	}
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,6 +149,9 @@ html_logo = "../static/i/favicon.png"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = [
+    'rtd_dark.css',
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -167,7 +167,8 @@ sphinx-autobuild==2021.3.14 \
 sphinx-rtd-theme==1.0.0 \
     --hash=sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8 \
     --hash=sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c
-    # via -r requirements/requirements.in
+    # via
+    #   -r requirements/requirements.in
 sphinxcontrib-applehelp==1.0.2 \
     --hash=sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a \
     --hash=sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Adds the `sphinx_rtd_dark_mode` extension, which provides for a toggleable dark theme

## Testing

- [ ] Build according to the instructions in the README
- [ ] Verify that you now see a button in the lower-right to switch between light and dark themes
- [ ] Verify that your theme preference persists after leaving and re-loading the site

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
