### PR TITLE
Center content when the display is sufficiently large

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -33,3 +33,11 @@
     </div>
 </div>
 {% endblock %}
+
+{% block footer %} {{ super() }}
+
+    <style>
+        .wy-nav-content { display: block; margin: 0 auto; }
+    </style>
+
+{% endblock %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This change centers content when the width of the screen is sufficiently large.

To see how this looks (without manually building the docs locally), you can refer to the short screencast below:

[Screencast from 2022-12-13 10-10-21.webm](https://user-images.githubusercontent.com/6131358/207388765-ba5a057d-b10d-4df5-9b15-f77583c3da6b.webm)

This is worth a wider discussion before merging in, but I wanted to make it easy for everyone to visualize the changes, and to have a place to collect feedback and comments.

## Testing

- [ ] Build according to the steps in the README
- [ ] Verify that the content is centered
- [ ] Optionally, test using multiple browser widths to see how it scales and adapts

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
