### PR TITLE
Don't use `text-align:justify` in dark mode

### DIFF
--- a/docs/_static/rtd_dark.css
+++ b/docs/_static/rtd_dark.css
@@ -93,10 +93,6 @@
 		color: #7dbdff
 	}
 
-	body {
-		text-align: justify;
-	}
-
 	.rst-content .section .admonition ul {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

The stylesheet introduced in #407 uses `text-align:justify` formatting in dark mode, which causes these kinds of spacing issues:

![Screenshot from 2023-01-04 09-57-19](https://user-images.githubusercontent.com/213636/210619404-85337e02-c24f-4423-a948-892fbc6a3992.png)

This PR preserves the stylesheet but removes that directive.

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
