### PR TITLE
Update the Gmail section in the OSSEC guide to match current requirements

### DIFF
--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -182,23 +182,22 @@ First you should `sign up for a new
 account <https://accounts.google.com/SignUp?service=mail>`__. While it's
 technically possible to use an existing Gmail account, it's best to
 compartmentalize these alerts from any of your other activities. Choose
-a strong and random passphrase for the new account. 
+a strong and random passphrase for the new account.
 
 Next, enable `Google's 2-Step Verification
-<https://www.google.com/landing/2step/>`__. This is required in order to 
-use SMTP with a username and password, which is needed for SecureDrop. 
+<https://safety.google/authentication/>`__. This is required in order to
+use SMTP with a username and password, which is needed for SecureDrop.
 
 After enabling 2-Step Verification, you'll then need to generate a new
 app password to use exclusively with SecureDrop. To do so,
-you will first want to `open the app password settings
-<https://myaccount.google.com/apppasswords>`__. From there, click "Select App",
-choose "Custom", assign it a name (such as "SecureDrop"), then click 
-"Generate."
+`open the app password settings <https://myaccount.google.com/apppasswords>`__.
+From there, click "Select App", choose "Custom", assign it a name (such as
+"SecureDrop"), then click "Generate."
 
 This will provide you with a 16-character password that you will need to use
 for the SMTP settings to enable OSSEC alerts.
 
-.. tip:: SMTP through Gmail will only work with a generated app password. 
+.. tip:: SMTP through Gmail will only work with a generated app password.
          The password for the Gmail account itself is not sufficient, and will
          not allow mail to be sent. In order to be able to create an app
          password, you must have 2-Step Verification enabled on the Gmail account.

--- a/docs/ossec_alerts.rst
+++ b/docs/ossec_alerts.rst
@@ -182,19 +182,31 @@ First you should `sign up for a new
 account <https://accounts.google.com/SignUp?service=mail>`__. While it's
 technically possible to use an existing Gmail account, it's best to
 compartmentalize these alerts from any of your other activities. Choose
-a strong and random passphrase for the new account. Skip the creation of
-a Google+ profile and continue straight to Gmail. Next, enable `Google's
-2-Step Verification <https://www.google.com/landing/2step/>`__. With
-2-Step Verification enabled, you won't use the normal account password
-in this configuration — it will not work; instead you must navigate
-(using the settings in the top right) to Account > Signing in > App
-passwords, and generate a new App password which you will use as the
-``sasl_passwd``.
+a strong and random passphrase for the new account. 
+
+Next, enable `Google's 2-Step Verification
+<https://www.google.com/landing/2step/>`__. This is required in order to 
+use SMTP with a username and password, which is needed for SecureDrop. 
+
+After enabling 2-Step Verification, you'll then need to generate a new
+app password to use exclusively with SecureDrop. To do so,
+you will first want to `open the app password settings
+<https://myaccount.google.com/apppasswords>`__. From there, click "Select App",
+choose "Custom", assign it a name (such as "SecureDrop"), then click 
+"Generate."
+
+This will provide you with a 16-character password that you will need to use
+for the SMTP settings to enable OSSEC alerts.
+
+.. tip:: SMTP through Gmail will only work with a generated app password. 
+         The password for the Gmail account itself is not sufficient, and will
+         not allow mail to be sent. In order to be able to create an app
+         password, you must have 2-Step Verification enabled on the Gmail account.
 
 Once the account is created you can log out and provide the values for
 ``sasl_username`` as your new Gmail username (without the domain),
 ``sasl_domain``, which is typically gmail.com (or your custom Google
-Apps domain), and ``sasl_passwd``. Remember to use the App password
+Apps domain), and ``sasl_passwd``. Remember to use the app password
 generated from the 2-step config for ``sasl_passwd``, as the primary
 account password won't work. The ``smtp_relay`` is smtp.gmail.com and
 the ``smtp_relay_port`` is 587.


### PR DESCRIPTION
## Status
Ready for review


## Description of Changes

* Description: This makes the requirement to use 2FA and generate an app password in Gmail more explicit. This also removes the reference to Google+ :cry: 

* Resolves #411

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
