### PR TITLE
Reoranize the admin section to a more Divio-like system

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,17 +15,19 @@ If you would like to contribute to SecureDrop, please see our
 `developer documentation <https://developers.securedrop.org/>`_.
 
 .. toctree::
-   :caption: User Guides
-   :name: userguidetoc
+   :caption: Overview
+   :name: overviewtoc
    :maxdepth: 2
 
+   what_makes_securedrop_unique
    source
    journalist
-   admin
-   passphrase_best_practices
+   getting_the_most_out_of_securedrop
+   training_schedule
+   getting_support
 
 .. toctree::
-   :caption: Install SecureDrop
+   :caption: SecureDrop Installation Guide
    :name: installtoc
    :maxdepth: 2
 
@@ -47,44 +49,42 @@ If you would like to contribute to SecureDrop, please see our
    configure_admin_workstation_post_install
    create_admin_account
    test_the_installation
-   onboarding_journalists
-   onboarding_admins
 
 .. toctree::
-   :caption: Deployment Best Practices
-   :name: deploymenttoc
+   :caption: Admin Guide
+   :name: adminguidetoc
+   :maxdepth: 2
+
+   admin
+   onboarding_journalists
+   onboarding_admins
+   yubikey_setup
+   logging
+   ossec_alerts
+   backup_and_restore
+   backup_workstations
+   update_tails_usbs
+   kernel_troubleshooting
+   https_source_interface
+   ssh_over_local_net
+   rebuild_admin
+   remote
+   tails_printing_guide
+   update_bios
+   offboarding
+   decommission
+
+.. toctree::
+   :caption: Best Practices
+   :name: bestpracticestoc
    :maxdepth: 2
 
    deployment_practices
+   passphrase_best_practices
    deployment/landing_page.rst
    deployment/minimum_security_requirements.rst
    deployment/whole_site_changes.rst
    deployment/sample_privacy_policy.rst
-
-.. toctree::
-   :caption: Topic Guides
-   :name: topictoc
-   :maxdepth: 2
-
-   getting_the_most_out_of_securedrop
-   what_makes_securedrop_unique
-   logging
-   ossec_alerts
-   remote
-   tails_printing_guide
-   https_source_interface
-   ssh_over_local_net
-   training_schedule
-   yubikey_setup
-   backup_and_restore
-   backup_workstations
-   update_tails_usbs
-   rebuild_admin
-   kernel_troubleshooting
-   getting_support
-   update_bios
-   offboarding
-   decommission
 
 .. toctree::
    :caption: Upgrade SecureDrop


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR is a first attempt at reorganizing the Admin portion of the SecureDrop documetation into a more Divio-like organizational structure. It also includes some other ancillary changes necessary for achieve this goal.

This is meant to serve as a starting point for discussion, which is greatly welcomed. I fully expect there to be a fair bit of back-and-forth and additional suggestions before it's ready to merge in (though it is in a mergeable state).

Before I describe what this PR achieves, I want to list some considerations that it intentionally does _not_ address:

### What This PR Does Not Do
* Reorganize any of the Source section of the documentation (further UX work needed)
* Reorganize any of the Journalist section of the documentation (further UX work needed)
* Create broken links to existing documentation or invalidate any prior support cases or information provided to external parties
* Add a specific section devoted to Maintenance for Admins (this is still wanted, but as that's largely new content, it's outside the scope of the PR)

### What This PR Does Do
* Makes the SecureDrop installation section more intentional about its goal of helping an end-user install and configure SecureDrop (Divio: "How-To Guide" / "Problem Oriented")
* Groups the Admin-related docs together and clarifies the intended audience, with the intention of having tutorial-related content in this section (Divio: "Tutorial"/"Learning-Oriented")
* Adds a brief section with broadly helpful information, which I have temporarily(?) named "Overview" (Divio: "Explanation"/"Understanding-Oriented")
* Eliminates the much-too-broad "Topic Guides" section
* Places all the 'best practices' documentation in the same, larger section (Divio:  "Reference"/"Information Oriented")

This partially addresses issue #417. I would vote to not close it or mark as complete until the documentation overhaul project is complete and the admin reorganization is in its "final" form.

### New Table of Contents

To make this easier for folks to contribute comments and suggestions for improvements, I'll provide a text-only version of the proposed Table of Contents:

```
Overview

    What Makes SecureDrop Unique
    Source Guide
    Journalist Guide
    Promoting Your SecureDrop Instance
    SecureDrop On-Site Training Schedule
    Getting Support

SecureDrop Installation Guide

    Overview
    Glossary
    Passphrases
    Hardware
    Before You Begin
    Create USB Boot Drives
    Set Up the Secure Viewing Station
    Set Up the Transfer Device and the Export Device
    Generate the Submission Key
    Set up the Admin Workstation
    Set Up the Network Firewall
    Setting Up a pfSense Network Firewall
    Setting Up An OPNSense Network Firewall
    Set Up the Servers
    Install SecureDrop
    Configure the Admin Workstation Post-Install and Create Backups
    Create an Admin Account on the Journalist Interface
    Test the Installation

Admin Guide

    Admin Guide
    Onboard Journalists
    Onboard Additional Admins
    Using a YubiKey with the Journalist Interface
    Investigating Logs
    OSSEC Guide
    Backing Up and Restoring Servers
    Backing Up and Restoring Workstations
    Updating Tails USBs
    Troubleshooting Kernel Updates
    HTTPS on the Source Interface
    SSH Over Local Network
    Rebuilding an Admin Workstation USB
    Accessing SecureDrop Remotely
    Setting Up a Printer in Tails
    BIOS Updates on the Servers
    Off-board Administrators and Journalists
    Decommission SecureDrop

Best Practices

    Overview
    Passphrase Best Practices
    Landing Page
    Minimum requirements for the SecureDrop environment
    Whole Site Changes
    Sample SecureDrop Privacy Policy

Upgrade SecureDrop

    Upgrade from 2.5.0 to 2.5.1
    Upgrade from 2.4.2 to 2.5.0
    Upgrade from 2.4.1 to 2.4.2
    Upgrade from 2.4.0 to 2.4.1
    Upgrade from 2.3.2 to 2.4.0
    Upgrade from 2.3.1 to 2.3.2

Threat Model

    Threat Model
    Data Flow Diagram
    Attacks and Countermeasures on the SecureDrop Environment
```


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
