### PR TITLE
Add a note about using the HWE kernel for NUC12s

### DIFF
--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -424,6 +424,11 @@ after disconnecting them.
 
 .. _nuc11_recommendation:
 
+Because of the newer hardware and the drivers required, you will need to use a
+newer Linux kernel than the one that ships by default in the version of Ubuntu
+Server we recommend. To do so, select the "Boot and Install with the HWE
+Kernel" option in the boot menu for Ubuntu Server.
+
 Intel 11th-gen NUC
 ~~~~~~~~~~~~~~~~~~
 We have tested and can recommend the `Intel NUC11PAHi3 <https://ark.intel.com/content/www/us/en/ark/products/205033/intel-nuc-11-performance-kit-nuc11pahi3.html>`__.

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -61,6 +61,12 @@ display a message on boot that shows which key should be pressed to
 enter the boot menu. Once you've entered the boot menu, select the
 installation media (USB or CD) and press Enter to boot it.
 
+On newer hardware, such as the NUC12s, you may need to use a newer Linux
+Kernel than the one that ships by default in **Ubuntu Server 20.04.5** in
+order to have more up-to-date hardware drivers. To use a newer Linux kernel,
+select **Boot and Install with the HWE Kernel** in the initial OS boot menu
+that appears prior to booting the Ubuntu image.
+
 After booting the Ubuntu image, select **Install Ubuntu Server**.
 
 Follow the steps to select your language, country and keyboard settings.

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -62,7 +62,7 @@ enter the boot menu. Once you've entered the boot menu, select the
 installation media (USB or CD) and press Enter to boot it.
 
 On newer hardware, such as the NUC12s, you may need to use a newer Linux
-Kernel than the one that ships by default in **Ubuntu Server 20.04.5** in
+kernel than the one that ships by default in **Ubuntu Server 20.04.5** in
 order to have more up-to-date hardware drivers. To use a newer Linux kernel,
 select **Boot and Install with the HWE Kernel** in the initial OS boot menu
 that appears prior to booting the Ubuntu image.


### PR DESCRIPTION
## Status

This adds a note in the NUC12 section of the hardware guide to let folks know to use the HWE kernel for NUC12s.

Just a note that I did not feel it necessary to explicitly recommend the BIOS update here, as it's not strictly required to boot the OS, and it's also [recommended elsewhere in our documentation.](https://docs.securedrop.org/en/stable/update_bios.html)

## Testing
- [ ] Make sure CI is happy
- [ ] Build locally and inspect the Hardware page visually

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
