### PR TITLE
Recommend a hard refresh to remove the old cached logo during a logo change

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -384,6 +384,10 @@ You should see a message appear indicating the change was a success.
 
 .. _test OSSEC alert:
 
+It may be necessary to hold the Shift key while pressing the Reload button in 
+the browser, which will force it to purge the cached version of the logo
+in order to see the new one.
+
 Testing OSSEC Alerts
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

* Description: This adds a note about pressing Shift and refreshing to clear the client-side cache when making a logo change (otherwise the new logo may not appear correctly)

* Resolves #421 

## Testing
- [ ] Make sure CI is happy
- [ ] Build locally and inspect the Hardware page visually

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
