### PR TITLE
Clarify the need to have Tails drives with persistent storage enabled to set up the SVS

### DIFF
--- a/docs/set_up_svs.rst
+++ b/docs/set_up_svs.rst
@@ -30,9 +30,13 @@ which cannot be heard by humans. If you have questions about repurposing
 hardware for the *Secure Viewing Station*, contact the `Freedom of the Press
 Foundation <https://securedrop.org/help>`__.
 
+The steps below assume you have already
+:doc:`created a Tails USB drive with Persistent Storage
+enabled <create_usb_boot_drives>`. If that is not the case, please review
+the previous page in the installation guide, then return here once the new
+Tails drive is ready.
 
-
-You should have a Tails drive clearly labeled “SecureDrop Secure Viewing
+The Tails drive should be clearly labeled “SecureDrop Secure Viewing
 Station”. If it's not labeled, label it right now, then boot it on the
 *Secure Viewing Station*. After it loads, you should see  the Tails
 `Welcome Screen <https://tails.boum.org/doc/first_steps/welcome_screen/index.en.html>`__.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This adds a small paragraph explaining the expectation that the user has already created a Tails USB drive with persistent storage enabled.

Just a small note: I've not added the same warning in the Remote SVS setup page, as it's not assumed to be part of the installation guide (this will be made clearer in the Admin docs reorg, currently in PR form at #418)

Related Issues: Related to PR: #419 

## Testing
- [ ] Verify that CI is happy
- [ ] Test locally

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
