### PR TITLE
Add dark-mode states for expanded nav items

### DIFF
--- a/docs/_static/rtd_dark.css
+++ b/docs/_static/rtd_dark.css
@@ -11,6 +11,18 @@
  * Modified by Nathan Dyer: 20230103
  */
 
+:root {
+    --dm-text-color: white;
+    --dm-link-new: #7dbdff;
+    --dm-link-visited: #7dbdff;
+    --dm-menu-border: #222;
+    --dm-menuhover-bg: #c1c1c1;
+    --dm-menuparent-bg: black;
+    --dm-parenthover-bg: #202020;
+    --dm-expandeditem-bg: #313131;
+    --dm-submenu-bg: #404040;
+}
+
 @media (prefers-color-scheme: dark) {
 
 	a {
@@ -23,6 +35,57 @@
 	pre {
 		background-color: #2d2d2d !important;
 	}
+
+
+/*
+** Vertical menu color overrides
+*/
+
+        .wy-menu-vertical li.current {
+            background: var(--dm-expandeditem-bg);
+            color: var(--dm-text-color);
+        }
+
+        .wy-menu-vertical li.current > a,
+        .wy-menu-vertical li.on a {
+            background: var(--dm-menuparent-bg);
+            color: var(--dm-text-color);
+        }
+
+        .wy-menu-vertical li.toctree-l1.current > a,
+        .wy-menu-vertical li.current.a {
+            border-color: var(--dm-menu-border);
+        }
+
+        .wy-menu-vertical li.current a {
+            color: var(--dm-text-color);
+        }
+
+        .wy-menu-vertical li.current a:hover {
+            background: var(--dm-menuhover-bg);
+        }
+
+        .wy-menu-vertical a:hover,
+        .wy-menu-vertical li.current > a.hover,
+        .wy-menu-vertical li.on a:hover {
+            background: var(--dm-parenthover-bg);
+        }
+
+        .wy-menu-vertical li.toctree-l2.current > a,
+        .wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a,
+        .wy-menu-vertical li.toctree-l2.current li.toctree-l3.current li.toctree-l4 > a {
+            background: var(--dm-submenu-bg);
+        }
+
+        .wy-menu-vertical li.toctree-l1 > a:hover,
+        .wy-menu-vertical li.toctree-l2 > a:hover,
+        .wy-menu-vertical li.toctree-l2.current > a:hover,
+        .wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a:hover,
+        .wy-menu-vertical li.toctree-l2.current
+        li.toctree-l3.current li.toctree-l4 > a:hover {
+            background: var(--dm-parenthover-bg);
+        }
+
 
 	.wy-nav-content {
 		background: #3c3c3c;


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

Updates the dark mode CSS to apply dark backgrounds consistently to expanded items in the vertical navigation menu.

## Testing
- [ ] switch browser pref to dark mode, open navigation submenus and confirm that they are consistently using dark background and light text, with dark hover states as appropriate 
- [ ] switch browser pref to light mode, open navigation submenus and confirm that they are consistently using light background and dark text

## Release 
n/a

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
