### PR TITLE
Update apt prod LFS repo name

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -326,7 +326,7 @@ linkcheck_ignore = [
     "https://forum.securedrop.org/admin/users/list/active",
     "https://weblate.securedrop.org/projects/securedrop/securedrop/#announcement",
     "https://weblate.securedrop.org/projects/securedrop/securedrop/#repository",
-    "https://github.com/freedomofpress/securedrop-debian-packages-lfs",
+    "https://github.com/freedomofpress/securedrop-apt-prod",
     r"https://weblate.securedrop.org/accounts/profile/.*",
     r"https://github.com/freedomofpress/securedrop/issues/.*",
     r"https://github.com/freedomofpress/securedrop/tree/.*",


### PR DESCRIPTION
## Status

Ready for review 


## Description of Changes

One mostly-trival repo name change for https://github.com/freedomofpress/securedrop-builder/issues/304 .


* Related Issues

Other PRs:
- https://github.com/freedomofpress/securedrop-dev-docs/pull/30
- https://github.com/freedomofpress/securedrop-builder/pull/400
- https://github.com/freedomofpress/securedrop-builder/pull/413
- https://github.com/freedomofpress/securedrop-builder-security/pull/4


## Testing

* Run a build after the repo is renamed (later today).

## Release 

N/A


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
