### PR TITLE
update transfer device setup

### DIFF
--- a/docs/set_up_transfer_and_export_device.rst
+++ b/docs/set_up_transfer_and_export_device.rst
@@ -89,8 +89,8 @@ Decide how to manage encryption passphrases
 -------------------------------------------
 Because files are copied between multiple computers, KeePassXC in Tails is not
 necessarily the most convenient option for managing the encryption passphrases for
-your *Transfer Device* or your *Export Device*. While Tails itself gives you the
-option to "remember" passphrases, this option does not work across reboots.
+your *Transfer Device* or your *Export Device*. Tails itself gives you the option 
+to "remember" passphrases, this will save it to your keyring in the persistent volume.
 
 A simple alternative is to make sure that every journalist stores the
 *Transfer Device* and *Export Device* passphrases in their own password manager,


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

* With Tails 5.9 and persistence enabled, the 'remember' passphrase to unlock export or transfer devices will save them to your keyring. The keyring is, because of the configured persistence settings, still there after reboot. 


## Testing

* Start with persistence enabled, unlock transfer usb, hit the remember checkbox when typing in the passphrase. Reboot, unlock persistence, check if the transfer usb disk gets unlocked without asking for your passphrase.


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000