### PR TITLE
Fix various links

### DIFF
--- a/docs/backup_workstations.rst
+++ b/docs/backup_workstations.rst
@@ -9,7 +9,7 @@ Backup the Workstations
 .. note::  This workflow will create a single USB drive with the data backed up
  from all Tails drives. If instead you'd like to create a single duplicate
  Tails drive, you should follow the official documentation
- `maintained by the Tails project <https://tails.boum.org/doc/first_steps/persistence/backup/index.en.html>`_.
+ `maintained by the Tails project <https://tails.boum.org/doc/persistent_storage/backup/index.en.html>`_.
 
 Now that you have set up the *Secure Viewing Station*, the *Admin Workstation*,
 and your *Journalist Workstations*, it is important you make a backup. Your USB

--- a/docs/create_usb_boot_drives.rst
+++ b/docs/create_usb_boot_drives.rst
@@ -82,7 +82,7 @@ For instructions on how to generate a strong passphrase, see :doc:`the
 Passphrases page <passphrases>`.
 
 Please use the instructions on the `Tails website
-<https://tails.boum.org/doc/first_steps/persistence/index.en.html>`__
+<https://tails.boum.org/doc/persistent_storage/index.en.html>`__
 to make the persistent volume on each Tails drive you create. When
 creating the persistence volume, you will be asked to select from a
 list of features, such as 'Personal Data'. You should enable **all** features by

--- a/docs/hardware.rst
+++ b/docs/hardware.rst
@@ -550,7 +550,7 @@ from exhaustive.
 
 We advise against using Macs, as there are many Tails compatibility issues both
 with older and with newer models. Instead, we recommend the
-`ThinkPad T series <https://www.lenovo.com/us/en/laptops/thinkpad/thinkpad-t-series/c/thinkpadt>`__.
+`ThinkPad T series <https://www.lenovo.com/us/en/c/laptops/thinkpad/thinkpadt>`__.
 The `ThinkWiki <https://www.thinkwiki.org/wiki/ThinkWiki>`__ is an excellent,
 independently maintained resource for verifying general Linux compatibility of
 almost any ThinkPad model.

--- a/docs/onboarding_admins.rst
+++ b/docs/onboarding_admins.rst
@@ -25,7 +25,7 @@ To onboard an additional administrator, you will need:
 
 To set up AW2, follow these steps:
 
-1. Boot AW1, `unlock its persistent volume <https://tails.boum.org/doc/first_steps/persistence/index.en.html#use>`__,
+1. Boot AW1, `unlock its persistent volume <https://tails.boum.org/doc/persistent_storage/use/index.en.html>`__,
    and `set an admin password on the welcome screen <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`__
 2. Ensure that Tails and the SecureDrop version on AW1 are up-to-date.
    If not, update now by following the :ref:`most recent upgrade guide <latest_upgrade_guide>`.

--- a/docs/servers.rst
+++ b/docs/servers.rst
@@ -239,7 +239,7 @@ Workstation* was set up with `SSH Client Persistence`_, this key will be saved
 on the *Admin Workstation* and can be used in the future to authenticate to
 the servers in order to perform administrative tasks.
 
-.. _SSH Client Persistence: https://tails.boum.org/doc/first_steps/persistence/index.en.html#index12h2
+.. _SSH Client Persistence: https://tails.boum.org/doc/persistent_storage/configure/index.en.html#index11h2
 
 First, generate the new SSH keypair:
 

--- a/docs/source.rst
+++ b/docs/source.rst
@@ -101,9 +101,8 @@ you have a couple of alternatives:
 * If your mail provider is less likely to be monitored, you can send a mail to
   gettor@torproject.org with the text "linux", "windows" or "osx" in the body
   (for your preferred operating system) and a bot will answer with instructions.
-* You can download a copy of Tor Browser for your operating system from the
-  `GitLab mirror <https://gitlab.com/thetorproject/gettorbrowser/tree/torbrowser-releases>`__
-  maintained by the Tor team.
+* You can request to receive the Tor Browser bundle via the
+  `@GetTor_bot on Telegram`_.
 
 While using Tor Browser on your personal computer helps hide your activity on
 the network, it will leave traces of its own installation on your local
@@ -123,6 +122,7 @@ making these decisions.
 
 .. _`Tor Project's website`: https://www.torproject.org/
 .. _`Tails operating system`: https://tails.boum.org/
+.. _`@GetTor_bot on Telegram`: https://t.me/gettor_bot
 
 Choose Who to Submit To
 -----------------------


### PR DESCRIPTION
- Tor GitLab mirror seems to no longer maintained, but they offer a Telegram bot now, so linking to that instead
- Tails has reorganized its persistent storage docs, leading to a bunch of 404s
- ThinkPad redirect seemed to be stalling out, so updating to its redirect target

## Status

Ready for review

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed 
- [x] You have previewed (`make docs`) docs at http://localhost:8000
