### PR TITLE
Update our firewall recommendations

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -132,13 +132,22 @@ Given all traffic first hits the network firewall as it faces the non-Tor public
 network, the admin should ensure that critical security patches are applied to the
 firewall.
 
-Be informed of potential updates to your network firewall. If you're using the
-network firewall recommended by FPF, you can subscribe to email updates from
-the `Netgate homepage`_ or follow the `Netgate blog`_ to be alerted when
-releases occur. If critical security updates need to be applied, you can do so
-through the firewall's pfSense WebGUI. Refer to our :ref:`Keeping pfSense up to
-date` documentation or the official `pfSense Upgrade Docs`_ for further details
-on how to update the suggested firewall.
+Because of recent changes to the frequency and scope of security updates, we do
+not recommend the use of pfSense Community Edition (CE). pfSense Plus continues
+to receive necessary security updates on a regular basis, and is provided
+with the purchase of most Netgate firewalls. If you wish to use a custom firewall
+or alternate option, we recommend using an OPNSense-based solution.
+
+If you're using one of the network firewalls recommended by FPF, you can 
+subscribe to email updates from the `Netgate homepage`_ or follow the
+`Netgate blog`_ to be alerted when releases occur. If critical security updates
+need to be applied, you can do so through the firewall's pfSense WebGUI.
+
+Refer to our :ref:`Keeping pfSense up to date` documentation or the official
+`pfSense Upgrade Docs`_ for further details on how to update the suggested firewall.
+
+No matter which vendor you go with, you should make it a priority to stay 
+informed of potential updates to your network firewall.
 
 .. _`Netgate homepage`: https://www.netgate.com/
 .. _`Netgate blog`: https://www.netgate.com/blog/

--- a/docs/network_firewall.rst
+++ b/docs/network_firewall.rst
@@ -13,11 +13,14 @@ IOS etc. We recommend that you use a firewall with at least four physical interf
 
 The documentation linked below describes the configuration procedure for pfSense-
 and OPNSense-based firewalls. One option not covered in this guide is to build
-your own network firewall and `install pfSense
-<https://docs.netgate.com/pfsense/en/latest/install/download-installer-image.html>`__
-or `OPNSense <https://opnsense.org/download/>`__ on it. However, for most
-installations, we recommend buying a dedicated firewall appliance with
-your firewall OS of choice pre-installed.
+your own network firewall and install `OPNSense <https://opnsense.org/download/>`__ 
+on it. However, for most installations, we recommend buying a dedicated firewall
+appliance with your firewall OS of choice pre-installed.
+
+Please note that we no longer recommend the use of pfSense Community Edition 
+(CE) due to changes in the frequency and scope of security updates made
+available there. pfSense Plus continues to receive necessary security updates
+on a regular basis, and is provided with the purchase of most Netgate firewalls.
 
 We currently recommend three firewalls in our :ref:`Hardware Guide <hardware_guide>`:
 


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

This expands our firewall documentation to clarify our recommendation to use either pfSense Plus or OPNSense, due to changes in the security updates cadence for pfSense CE

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
