### PR TITLE
Add link to dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 SecureDrop is an open-source whistleblower submission system that media organizations can use to securely accept documents from, and communicate with anonymous sources. It was originally created by the late Aaron Swartz and is currently managed by the [Freedom of the Press Foundation](https://freedom.press).
 
-This repository is used to build the [public documentation](https://docs.securedrop.org/) for SecureDrop.
+This repository is used to build the [public end user documentation](https://docs.securedrop.org/) for SecureDrop.
+
+For developer documentation, please see https://developers.securedrop.org/ and the [corresponding GitHub repository](https://github.com/freedomofpress/securedrop-dev-docs/).
 
 ## Quickstart
 


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Cross-link dev docs, mostly for testing deploy pipeline, but should be a useful change in its own right.