### PR TITLE
Clarified landing page monitoring suggestion, fixed broken links

### DIFF
--- a/docs/admin/deployment/landing_page.rst
+++ b/docs/admin/deployment/landing_page.rst
@@ -405,12 +405,17 @@ configuration example provided by ProPublica.
              for inclusion in the directory and does not necessarily prevent
              the instance from being included.
 
-Change detection monitoring for the web application configuration and *Landing Page* content
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Set up change detection monitoring for the web application configuration and *Landing Page* content
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-OSSEC is a free and open source host-based intrusion detection suite
+If possible, you should set up monitoring to detect changes to the *Landing Page* and the
+configuration files of the web server hosting the page. If you do not have an existing
+monitoring system for your site, OSSEC is a free and open source host-based intrusion detection suite
 that includes a file integrity monitor. More information can be found
 `here. <https://www.ossec.net/>`__
+
+.. note:: We do not recommmend using the *Monitor Server* to monitor your landing page. It should be used
+  for the *Application Server* only.
 
 Don't log access to the *Landing Page* in the webserver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/admin/installation/create_usb_boot_drives.rst
+++ b/docs/admin/installation/create_usb_boot_drives.rst
@@ -125,7 +125,7 @@ Ubuntu Introduction
   exactly as there are some "gotchas" that may cause your SecureDrop setup to break.
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-20.04.5 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
+20.04.6 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media.
 
 .. _download_ubuntu:
@@ -136,7 +136,7 @@ Download the Ubuntu Installation Media
 The installation media and the files required to verify it are available on the
 `Ubuntu Releases page`_. You will need to download the following files:
 
-* `ubuntu-20.04.5-live-server-amd64.iso`_
+* `ubuntu-20.04.6-live-server-amd64.iso`_
 * `SHA256SUMS`_
 * `SHA256SUMS.gpg`_
 
@@ -145,10 +145,10 @@ Alternatively, you can use the command line:
 .. code:: sh
 
    cd ~/Downloads
-   curl -OOO https://releases.ubuntu.com/20.04.5/{ubuntu-20.04.5-live-server-amd64.iso,SHA256SUMS{,.gpg}}
+   curl -OOO https://releases.ubuntu.com/20.04.6/{ubuntu-20.04.6-live-server-amd64.iso,SHA256SUMS{,.gpg}}
 
 .. _Ubuntu Releases page: https://releases.ubuntu.com/
-.. _ubuntu-20.04.5-live-server-amd64.iso: https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso
+.. _ubuntu-20.04.6-live-server-amd64.iso: https://releases.ubuntu.com/20.04/ubuntu-20.04.6-live-server-amd64.iso
 .. _SHA256SUMS: https://releases.ubuntu.com/20.04/SHA256SUMS
 .. _SHA256SUMS.gpg: https://releases.ubuntu.com/20.04/SHA256SUMS.gpg
 
@@ -196,12 +196,12 @@ key") means that you are not ready to proceed. ::
 
 The next and final step is to verify the Ubuntu image. ::
 
-    sha256sum -c <(grep ubuntu-20.04.5-live-server-amd64.iso SHA256SUMS)
+    sha256sum -c <(grep ubuntu-20.04.6-live-server-amd64.iso SHA256SUMS)
 
 If the final verification step is successful, you should see the
 following output in your terminal. ::
 
-    ubuntu-20.04.5-live-server-amd64.iso: OK
+    ubuntu-20.04.6-live-server-amd64.iso: OK
 
 .. caution:: If you do not see the line above it is not safe to proceed with the
              installation. If this happens, please contact us at

--- a/docs/admin/installation/servers.rst
+++ b/docs/admin/installation/servers.rst
@@ -37,7 +37,7 @@ Install Ubuntu
 ---------------
 
 The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-20.04.5 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
+20.04.6 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media.
 
 You should have already performed this step while setting up the Tails USB
@@ -62,7 +62,7 @@ enter the boot menu. Once you've entered the boot menu, select the
 installation media (USB or CD) and press Enter to boot it.
 
 On newer hardware, such as the NUC12s, you may need to use a newer Linux
-kernel than the one that ships by default in **Ubuntu Server 20.04.5** in
+kernel than the one that ships by default in **Ubuntu Server 20.04.6** in
 order to have more up-to-date hardware drivers. To use a newer Linux kernel,
 select **Boot and Install with the HWE Kernel** in the initial OS boot menu
 that appears prior to booting the Ubuntu image.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -2,7 +2,7 @@ Glossary
 ========
 
 A number of terms used in this guide, and in the `SecureDrop workflow
-diagram <what_is_securedrop.html>`__, are specific to SecureDrop. 
+diagram <what_is_securedrop>`, are specific to SecureDrop. 
 The list below attempts to enumerate and define these terms.
 
 

--- a/docs/threat_model/mitigations.rst
+++ b/docs/threat_model/mitigations.rst
@@ -231,7 +231,7 @@ Countermeasures in User Behavior Recommendations
 -  `Source Guide <https://docs.securedrop.org/en/stable/source.html>`__ gives instructructions on best practices for the entire submission workflow
 -  Source interface banner suggests that user disables JS (high security settings in Tor Browser)
 -  `Journalist Guide <https://docs.securedrop.org/en/stable/journalist.html>`__ informs users of malware risks, the importance of strict compartmentalization of SecureDrop-related activities
--  `SecureDrop Deployment Guide <https://docs.securedrop.org/en/stable/deployment_practices.html>`__ gives best practices for proper administration of the SecureDrop system, and its public-facing properties like the Landing Page
+-  `SecureDrop Deployment Guide <https://docs.securedrop.org/en/stable/admin/deployment/deployment_practices.html>`__ gives best practices for proper administration of the SecureDrop system, and its public-facing properties like the Landing Page
 -  `Admin Guide <https://docs.securedrop.org/en/stable/admin.html>`__ gives instructions for long-term maintenance of the technical properties of the SecureDrop system, as well as operations to support Journalists
 -  All Admin tasks are completed over Tor/Tor authenticated onion services after installation
 -  Any Journalist/Admin password/2FA credentials resets can only be done by an Admin with password-protected SSH capability or authenticated Onion Service credentials.


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review 

## Description of Changes

- Clarifies that the Monitor Server should not be set up to monitor landing pages.
- fixes broken internal links
- Updates linked Focal version to 20.04.6


<!-- List any other unresolved, but relevant issues that this PR addresses -->


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
*

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* 


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
