### PR TITLE
Document workaround for SecureDrop Issue 6903

### DIFF
--- a/docs/admin/deployment/onboarding_journalists.rst
+++ b/docs/admin/deployment/onboarding_journalists.rst
@@ -80,6 +80,7 @@ to access the servers over SSH.
 
     ~/Persistent/securedrop/install_files/ansible-base/app-sourcev3-ths
     ~/Persistent/securedrop/install_files/ansible-base/app-journalist.auth_private
+    ~/Persistent/securedrop/install_files/ansible-base/group_vars/all/site-specific
 
   Then, boot into the new *Journalist Workstation* USB.
 
@@ -103,9 +104,15 @@ to access the servers over SSH.
     cd ~/Persistent/securedrop
     ./securedrop-admin setup
     ./securedrop-admin tailsconfig
+    rm install_files/ansible-base/group_vars/all/site-specific
 
   .. note:: The ``setup`` command may take several minutes, and may fail partway
             due to network issues. If so, run it again before proceeding.
+            
+            The ``site-specific`` file should be removed after running the
+            ``tailsconfig`` command, as it contains sensitive network and
+            user information that should not reside on the *Journalist
+            Workstation.*
 
 - Once the ``tailsconfig`` command is complete, verify that the *Source* and
   *Journalist Interfaces* are accessible at their v3 addresses via the


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Related to [SecureDrop issue #6903](https://github.com/freedomofpress/securedrop/issues/6903)

And [SecureDrop PR #6905](https://github.com/freedomofpress/securedrop/pull/6905)

In order for the tailsconfig command to work correctly in SecureDrop 2.6.0, it needs to have access to the site-specific file from the Admin Workstation.

A fix for this issue will be released, so this addition will not be needed permanently. That said, until the next SecureDrop release is available, anyone doing a clean install will need to follow this amended procedure for the Journalist Workstation deployment to complete without error.



## Testing
* [ ] CI passes
* [ ] Visual review

## Release 

This should be tagged in a stable release ASAP, as it will be needed until the next version of SecureDrop gets released.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
