### PR TITLE
Replace APU4D4 with Protectli Vault 4-port in firewall recommendations

### DIFF
--- a/docs/admin/installation/hardware.rst
+++ b/docs/admin/installation/hardware.rst
@@ -659,13 +659,13 @@ for additional background.
 Network Firewall
 ^^^^^^^^^^^^^^^^
 
-We currently recommend 3 network firewalls:
+We recommend a 4 NIC network firewall and currently provide setup instructions for pfSense and OPNSense. Suitable models include:
 
-* the `TekLager APU4D4 <https://teklager.se/en/products/routers/apu4d4-open-source-router>`__, running `OPNSense <https://opnsense.org/>`__. It has 4 NICs and ports.
+* the `Protectli Vault 4-Port <https://protectli.com/vault-4-port/>`__, running `OPNSense <https://opnsense.org/>`__ configured with `coreboot <https://www.coreboot.org/>`__.
 * the `Netgate SG-4100 <https://shop.netgate.com/products/4100-base-pfsense>`__
-  running `pfSense <https://www.pfsense.org/>`__. It has 4 discrete LAN ports and two dedicated WAN ports.
+  running `pfSense Plus <https://www.pfsense.org/>`__.
 * the `Netgate SG-6100 <https://shop.netgate.com/products/6100-base-pfsense>`__
-  running `pfSense <https://www.pfsense.org/>`__. It also has 4 discrete LAN ports with multiple WAN port options. It has more ports than are typically required for SecureDrop, but can be used if the other cheaper firewalls can't be procured.
+  running `pfSense Plus <https://www.pfsense.org/>`__. This device is overspecced for SecureDrop's purposes, but can be used if the other cheaper firewalls can't be procured.
 
 .. _printers_tested_by_fpf:
 

--- a/docs/admin/installation/network_firewall.rst
+++ b/docs/admin/installation/network_firewall.rst
@@ -30,9 +30,12 @@ We currently recommend three firewalls in our :ref:`Hardware Guide <hardware_gui
 * The `Netgate SG-6100 <https://shop.netgate.com/products/6100-base-pfsense>`__,
   a pfSense-based firewall with 8 network interfaces: 4 WAN ports and 4 LAN ports.
 
-* The `TekLager APU4D4 <https://teklager.se/en/products/routers/apu4d4-open-source-router>`__,
-  an OPNSense-based open-source hardware firewall with 4 network interfaces: WAN,
-  LAN, OPT1, and OPT2.
+* The `Protectli Vault 4-Port <https://protectli.com/vault-4-port/>`__
+  (with `coreboot <https://www.coreboot.org/>`__),
+  an OPNSense-based open-source hardware firewall  with 4 configurable
+  network interfaces.
+  
+  
 
 Configuration: pfSense
 ----------------------


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes
* Description: Replace APU4D4 with Protectli Vault in firewall recommendations (see https://docs.dasharo.com/variants/pc_engines/post-eol-fw-announcement/ and https://www.pcengines.ch/eol.htm).
* Slight rewording to emphasize attributes of supported firewall 
* Clarify that Netgate hardware uses pfSense Plus
* Resolves #481
* Related: #333 (still need to make this change with whatever OPNSense firewall we recommend)

## Testing
* visual review, CI passes

## Release 
* n/a 

## Checklist (Optional)
- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
