### PR TITLE
Document the upgrade flag in the Admin Workstation troubleshooting guide

### DIFF
--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -1,0 +1,49 @@
+Troubleshooting Workstation Updates
+===================================
+
+This section includes some general troubleshooting instructions for common workstation
+update issues. For additional, version-specific issues and recommended actions,
+please see the relevant admin upgrade guide.
+
+Performing a manual update
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sometimes, when an update doesn't go according to plan, it's necessary to perform a 
+manual update and clear the update flag.
+
+If the graphical updater fails and you want to perform a manual update instead,
+first delete the graphical updater's temporary flag file, if it exists (the
+``.`` before ``securedrop`` is not a typo): ::
+
+  rm ~/Persistent/.securedrop/securedrop_update.flag
+
+This will prevent the graphical updater from attempting to re-apply the failed
+update and has no bearing on future updates. You can now perform a manual
+update by running the following commands: ::
+
+  cd ~/Persistent/securedrop
+  git fetch --tags
+  gpg --keyserver hkps://keys.openpgp.org --recv-key \
+   "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
+  git tag -v <your_securedrop_version>
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 2359E6538C0613E652955E6C188EDD3B7B22E6A3
+    gpg: Good signature from "SecureDrop Release Signing Key <securedrop-release-key-2021@freedom.press>" [unknown]
+
+
+Please verify that each character of the fingerprint above matches what is
+on the screen of your workstation. A warning that the key is not certified
+is normal and expected. If the output includes the lines above, you can check
+out the new release: ::
+
+    git checkout <your_securedrop_version>
+
+.. important:: If you do see the warning "refname '<your_securedrop_version>' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following commands: ::
+
+  ./securedrop-admin setup
+  ./securedrop-admin tailsconfig

--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -24,7 +24,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v <your_securedrop_version>
+  git tag -v 2.6.1
 
 The output should include the following two lines: ::
 
@@ -37,9 +37,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout <your_securedrop_version>
+    git checkout 2.6.1
 
-.. important:: If you do see the warning "refname '<your_securedrop_version>' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.6.1' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,6 +137,7 @@ Get Started
    admin/maintenance/ossec_alerts
    admin/maintenance/backup_and_restore
    admin/maintenance/backup_workstations
+   admin/maintenance/update_workstations
    admin/maintenance/update_tails_usbs
    admin/maintenance/kernel_troubleshooting
    admin/maintenance/rebuild_admin

--- a/update_version.sh
+++ b/update_version.sh
@@ -13,6 +13,7 @@ readonly OLD_VERSION=$(grep -oP '(?<=^version \= ")\d+\.\d+\.\d+' docs/conf.py)
 
 sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/admin/installation/set_up_admin_tails.rst
 sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/admin/maintenance/backup_and_restore.rst
+sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/admin/maintenance/update_workstations.rst
 sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" docs/conf.py
 sed -i "s@$(echo "${OLD_VERSION}" | sed 's/\./\\./g')@$NEW_VERSION@g" pyproject.toml
 


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

* Resolves #501 
<!-- Add an issue number immediately after the # symbol to link to an existing issue report --> 

As agreed in the issue (#501) discussion, this PR adds a new article to the "Admin Guide: Maintenance" section of the docs. Right now the new article is essentially a copy/paste of the [performing a manual update](https://docs.securedrop.org/en/stable/upgrade/2.6.0_to_2.6.1.html#performing-a-manual-update) section, but I have used placeholders for any version specific inputs to make the new article more general. There is also additional summary text introducing the article. Although it repeats existing documentation, the intention is to heighten the visibility of this manual update procedure, as for some users it is otherwise hard to find.

### Changes
* Create new article in Admin Guide: Maintenance section: "Troubleshooting Workstation Updates"
* Edit the version-specific text to be more general
* Add some summary

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
- [ ] CI passes
- [ ] Visual review

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
