### PR TITLE
Update version numbers and add upgrade guide for 2.7.0

### DIFF
--- a/docs/admin/installation/set_up_admin_tails.rst
+++ b/docs/admin/installation/set_up_admin_tails.rst
@@ -139,7 +139,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.6.1
+    git tag -v 2.7.0
 
 The output should include the following two lines:
 
@@ -160,9 +160,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.6.1
+    git checkout 2.7.0
 
-.. important:: If you see the warning ``refname '2.6.1' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.7.0' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/backup_and_restore.rst
+++ b/docs/admin/maintenance/backup_and_restore.rst
@@ -229,7 +229,7 @@ Migrating Using a V2+V3 or V3-Only Backup
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.6.1
+      git tag -v 2.7.0
 
    The output should include the following two lines:
 
@@ -250,10 +250,10 @@ Migrating Using a V2+V3 or V3-Only Backup
 
    .. code:: sh
 
-      git checkout 2.6.1
+      git checkout 2.7.0
 
    .. important::
-      If you see the warning ``refname '2.6.1' is ambiguous`` in the
+      If you see the warning ``refname '2.7.0' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
@@ -472,7 +472,7 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.6.1
+      git tag -v 2.7.0
 
    The output should include the following two lines:
 
@@ -491,11 +491,11 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
    .. code:: sh
 
-      git checkout 2.6.1
+      git checkout 2.7.0
 
 
    .. important::
-      If you see the warning ``refname '2.6.1' is ambiguous`` in the
+      If you see the warning ``refname '2.7.0' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -24,7 +24,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.6.1
+  git tag -v 2.7.0
 
 The output should include the following two lines: ::
 
@@ -37,9 +37,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.6.1
+    git checkout 2.7.0
 
-.. important:: If you do see the warning "refname '2.6.1' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.7.0' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.6.1"
+version = "2.7.0"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,6 +150,7 @@ Get Started
    :maxdepth: 2
    :hidden:
 
+   upgrade/2.6.1_to_2.7.0.rst
    upgrade/2.6.0_to_2.6.1.rst
    upgrade/2.5.2_to_2.6.0.rst
    upgrade/2.5.1_to_2.5.2.rst

--- a/docs/upgrade/2.6.1_to_2.7.0.rst
+++ b/docs/upgrade/2.6.1_to_2.7.0.rst
@@ -3,6 +3,31 @@
 Upgrade from 2.6.1 to 2.7.0
 ===========================
 
+.. note::
+
+   This release will remove support for submission PGP keys with legacy 
+   SHA-1-based binding signatures. The SecureDrop Journalist Interface
+   will not start when the instance has been configured with such a key.
+   If you have set up SecureDrop according to our documentation, you are
+   not using such keys; no SecureDrop instances known to us are affected
+   by this change.
+
+   If you are unsure if you will be affected by this change, you can 
+   reach out to us for support. Our recommended course of action is to
+   check your Submission Public Key, available at the /public-key
+   endpoint of your SecureDrop Source Interface onion url, using the
+   ``sq-keyring-linter`` program installable on your Admin Workstation.
+   If your key contains insecure SHA-1-based signatures, we suggest
+   creating a new Submission Keypair according to our documentation.
+   You should not delete the old key from your Secure Viewing Station,
+   so that you can still decrypt old submissions. We are happy to 
+   assist you with this process. As a reminder, all key material should
+   be generated on an air-gapped machine, and should never reside on a
+   network-connected device.
+
+   For more detailed information about why keys with SHA-1 signatures are
+   insecure, see https://sequoia-pgp.org/blog/2023/02/01/202302-happy-sha1-day/.
+
 Update Servers to SecureDrop 2.7.0
 ----------------------------------
 Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop

--- a/docs/upgrade/2.6.1_to_2.7.0.rst
+++ b/docs/upgrade/2.6.1_to_2.7.0.rst
@@ -5,18 +5,20 @@ Upgrade from 2.6.1 to 2.7.0
 
 .. note::
 
-   This release will remove support for submission PGP keys with legacy 
+   This release will remove support for Submission Public Keys with legacy
    SHA-1-based binding signatures. The SecureDrop Journalist Interface
-   will not start when the instance has been configured with such a key.
-   If you have set up SecureDrop according to our documentation, you are
-   not using such keys; no SecureDrop instances known to us are affected
-   by this change.
+   will not start when the instance has been configured with such a key,
+   and the Source Interface will state that the instance is temporarily
+   offline. If you have set up SecureDrop according to our documentation, 
+   you are not using such keys; no SecureDrop instances known to us are 
+   affected by this change.
 
    If you are unsure if you will be affected by this change, you can 
    reach out to us for support. Our recommended course of action is to
    check your Submission Public Key, available at the /public-key
    endpoint of your SecureDrop Source Interface onion url, using the
-   ``sq-keyring-linter`` program installable on your Admin Workstation.
+   ``sq-keyring-linter`` program, which is available by default on your
+   Admin Workstation starting with Tails version 5.19.
    If your key contains insecure SHA-1-based signatures, we suggest
    creating a new Submission Keypair according to our documentation.
    You should not delete the old key from your Secure Viewing Station,

--- a/docs/upgrade/2.6.1_to_2.7.0.rst
+++ b/docs/upgrade/2.6.1_to_2.7.0.rst
@@ -1,23 +1,20 @@
-Upgrade from 2.6.0 to 2.6.1
+.. _latest_upgrade_guide:
+
+Upgrade from 2.6.1 to 2.7.0
 ===========================
 
-Update Servers to SecureDrop 2.6.1
+Update Servers to SecureDrop 2.7.0
 ----------------------------------
-This point release contains an update for Tails workstations only. 
+Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop
+automatically within 24 hours of the release.
 
-Server code is not be affected and will remain at version 2.6.0.
-
-Update Workstations to SecureDrop 2.6.1
+Update Workstations to SecureDrop 2.7.0
 ---------------------------------------
 
 Updating Tails and replacing short passphrases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Before upgrading your Workstations to SecureDrop 2.6.1, we 
-strongly recommend that you first upgrade to Tails 5.16.1, which includes
-important security fixes related to the recent
-`Downfall <https://downfall.page/>`_ and
-`Inception <https://www.amd.com/en/resources/product-security/bulletin/amd-sb-7005.html>`_
-vulnerabilities.
+Before upgrading your Workstations to SecureDrop 2.7.0, we 
+strongly recommend that you first upgrade to Tails 5.19.
 
 Using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -33,7 +30,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.boum.org/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.6.1 by clicking "Update Now":
+Perform the update to 2.7.0 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -53,7 +50,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.6.1
+  git tag -v 2.7.0
 
 The output should include the following two lines: ::
 
@@ -66,9 +63,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.6.1
+    git checkout 2.7.0
 
-.. important:: If you do see the warning "refname '2.6.1' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.7.0' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "securedrop-docs"
-version = "2.6.1"
+version = "2.7.0"
 description = "SecureDrop documentation for journalists, sources and administrators"
 authors = ["SecureDrop team <securedrop@freedom.press>"]
 readme = "README.md"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Description: Bumps the version numbers, and adds an upgrade guide for the 2.7.0 release.

* Resolves #509 

## Testing
* [ ] CI passes
* [ ] Visual review

## Release 
* This should be merged and a new stable release tagged in tandem with the SecureDrop 2.7.0 release


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
