### PR TITLE
Document the process for manually checking for apt updates prior to running `securedrop-admin setup`

### DIFF
--- a/docs/admin/deployment/onboarding_journalists.rst
+++ b/docs/admin/deployment/onboarding_journalists.rst
@@ -99,7 +99,8 @@ to access the servers over SSH.
 - Open a terminal and run the following commands:
 
   .. code:: sh
-
+    
+    sudo apt update
     cd ~/Persistent/securedrop
     ./securedrop-admin setup
     ./securedrop-admin tailsconfig

--- a/docs/admin/deployment/ssh_over_local_net.rst
+++ b/docs/admin/deployment/ssh_over_local_net.rst
@@ -51,6 +51,7 @@ latest production release.
 
 .. code:: sh
 
+    $ sudo apt update
     $ cd ~/Persistent/securedrop
     $ ./securedrop-admin update
     $ ./securedrop-admin setup

--- a/docs/admin/installation/install.rst
+++ b/docs/admin/installation/install.rst
@@ -11,6 +11,7 @@ command:
 
 .. code:: sh
 
+    sudo apt update
     ./securedrop-admin setup
 
 The package installation will take approximately 10 minutes or longer, depending

--- a/docs/admin/maintenance/rebuild_admin.rst
+++ b/docs/admin/maintenance/rebuild_admin.rst
@@ -347,6 +347,7 @@ previous steps. To do so, connect to the Tor network on the
 
 .. code:: sh
 
+ sudo apt update
  cd ~/Persistent/securedrop
  ./securedrop-admin setup
  ./securedrop-admin sdconfig

--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -45,5 +45,6 @@ out the new release: ::
 
 Finally, run the following commands: ::
 
+  sudo apt update
   ./securedrop-admin setup
   ./securedrop-admin tailsconfig


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

* Description: This PR instructs users to manually check for apt updates before running `./securedrop-admin setup`. This is necessary to work around an issue that was discovered, starting with Tails 5.20.

* Related Issues
https://github.com/freedomofpress/securedrop/issues/7084


## Testing
* [ ] CI passes
* [ ] Visual review

## Release 
* If accepted, we should push a stable docs release ASAP to try and prevent folks from getting tripped up by this

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
