### PR TITLE
Have dependabot update GitHub Actions too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "all"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review

## Description of Changes

See <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot>.

This will primarily be used to keep actions/checkout up to date (it's already on v4):
![Screenshot 2024-01-05 at 14-33-32 Dependencies · freedomofpress_securedrop-docs](https://github.com/freedomofpress/securedrop-docs/assets/81392/f2409e52-90e8-456e-a104-59267732f117)



## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] Visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
