### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "all"
+    groups:
+        dependencies:
+          patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Inspired by https://github.com/freedomofpress/securedrop-client/pull/1824 to ease reviewing the steady pile of updates here as well.

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
