### PR TITLE
docs: document Tor proof-of-work defense via `securedrop-admin sdconfig`

### DIFF
--- a/docs/admin/deployment/tor_pow.rst
+++ b/docs/admin/deployment/tor_pow.rst
@@ -1,0 +1,51 @@
+Tor Proof-of-Work Defense on the *Source Interface*
+===================================================
+
+The SecureDrop *Source Interface* is served as an onion service with an
+``.onion`` URL, requiring Tor Browser to access it over the Tor network.  Tor is
+sometimes targeted for denial-of-service (DoS) attacks that can `slow down the
+Tor network as a whole <https://blog.torproject.org/tor-network-ddos-attack/>`_
+as well as burden individual onion services, including SecureDrops.
+
+Tor now includes a `proof-of-work (PoW) defense
+<https://community.torproject.org/onion-services/ecosystem/technology/pow/>`_
+against denial-of-service attacks that can be turned on for individual onion
+services.  As of SecureDrop 2.9.0, new SecureDrops have this feature enabled by
+default, and we encourage all SecureDrop administrators to turn it on for their
+instances.  While this measure can't speed up the Tor network as a whole if it's
+slow, it can protect your SecureDrop from being attacked specifically; and more
+onion services running with this feature helps improve the resilience of the Tor
+network.
+
+
+Enabling the proof-of-work defense
+----------------------------------
+
+Make sure you have :doc:`installed SecureDrop already
+<../installation/install>`.  Then, on the *Admin Workstation*:
+
+.. code:: sh
+
+  cd ~/Persistent/securedrop
+  ./securedrop-admin sdconfig
+
+The prompts will include::
+
+    Enable Tor's proof-of-work defense against denial-of-service attacks for the Source Interface?: yes
+
+Type <Enter> to accept the new default ``yes`` value.  When you finish the
+prompts, rerun the installation script::
+
+    ./securedrop-admin install
+
+The Tor configuration will be updated to enable the proof-of-work defense.  When
+the script finishes, confirm that you can access the Source Interface.
+
+
+Disabling the proof-of-work-defense
+-----------------------------------
+
+Follow the instructions given above for enabling the proof-of-work defense, but
+answer ``no`` at the prompt::
+
+    Enable Tor's proof-of-work defense against denial-of-service attacks for the Source Interface?: no

--- a/docs/admin/deployment/tor_pow.rst
+++ b/docs/admin/deployment/tor_pow.rst
@@ -18,11 +18,16 @@ onion services running with this feature helps improve the resilience of the Tor
 network.
 
 
+.. _enable_tor_pow:
+
 Enabling the proof-of-work defense
 ----------------------------------
 
-Make sure you have :doc:`installed SecureDrop already
-<../installation/install>`.  Then, on the *Admin Workstation*:
+If you're :doc:`installing SecureDrop for the first time
+<../installation/install>`, the proof-of-work defense will be enabled by
+default, unless you :ref:`explicitly disable it <disable_tor_pow>`.
+
+To enable it on an existing SecureDrop instance, on the *Admin Workstation*:
 
 .. code:: sh
 
@@ -42,10 +47,12 @@ The Tor configuration will be updated to enable the proof-of-work defense.  When
 the script finishes, confirm that you can access the Source Interface.
 
 
+.. _disable_tor_pow:
+
 Disabling the proof-of-work-defense
 -----------------------------------
 
-Follow the instructions given above for enabling the proof-of-work defense, but
-answer ``no`` at the prompt::
+Follow the instructions above for :ref:`enabling the proof-of-work defense
+<enable_tor_pow>`, but answer ``no`` at the prompt::
 
     Enable Tor's proof-of-work defense against denial-of-service attacks for the Source Interface?: no

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,6 +121,7 @@ Get Started
    admin/deployment/onboarding_journalists
    admin/deployment/onboarding_admins
    admin/deployment/yubikey_setup
+   admin/deployment/tor_pow
    admin/deployment/https_source_interface
    admin/deployment/ssh_over_local_net
    admin/deployment/remote


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Closes #568 by:
1. explaining Tor's proof-of-work defense; and
2. giving instructions on how to enable and disable it.


## Testing

- [x] Visual review.
- [x] Is this a fair summary of our decision to enable this feature in `sdconfig` by default going forward?

    https://github.com/freedomofpress/securedrop-docs/blob/1b9209ec5511de0fb4ac34fbb30531cea8242f96/docs/admin/deployment/tor_pow.rst?plain=1#L13-L15

## Release 

This should be called out prominently in the v2.9.0 release notes.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
