### PR TITLE
Clarify requirement prohibiting subdomains

### DIFF
--- a/docs/admin/deployment/landing_page.rst
+++ b/docs/admin/deployment/landing_page.rst
@@ -140,10 +140,11 @@ let us know and we can remove your instance from the directory.
 URL and Location
 ----------------
 
-Ideally you would not use a separate subdomain, but would use a path at
-your top-level domain, e.g. organization.com/securedrop. This is because
-TLS does not encrypt the hostname, so a SecureDrop user whose connection
-is being monitored would be trivially discovered.
+Your *Landing Page* must be a path at your top-level domain, e.g. 
+organization.com/securedrop, rather than a subdomain (e.g., 
+securedrop.organization.com). This is because TLS does not encrypt the hostname,
+so a SecureDrop user whose connection is being monitored would be trivially
+discovered if you were to use a subdomain.
 
 If the *Landing Page* is deployed on the same domain as another site, you
 might consider having some specific configuration (such as the security

--- a/docs/admin/deployment/landing_page.rst
+++ b/docs/admin/deployment/landing_page.rst
@@ -142,7 +142,7 @@ URL and Location
 
 Your *Landing Page* must be a path at your top-level domain, e.g. 
 organization.com/securedrop, rather than a subdomain (e.g., 
-securedrop.organization.com). This is because TLS does not encrypt the hostname,
+securedrop.organization.com). This is because DNS and TLS do not always encrypt the hostname,
 so a SecureDrop user whose connection is being monitored would be trivially
 discovered if you were to use a subdomain.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR modifies the language in the *Landing Page* section to make it clear that subdomains should not be used.


## Release 

Can be tagged in stable release once merged.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
