### PR TITLE
Add the "-O" flag to scp commands to force scp instead of sftp

### DIFF
--- a/docs/admin/deployment/offboarding.rst
+++ b/docs/admin/deployment/offboarding.rst
@@ -84,13 +84,13 @@ SSH key, you should rotate the key in the following manner.
 
     .. code:: sh
 
-      scp /home/amnesia/.ssh/newkey.pub scp://app
+      scp -O /home/amnesia/.ssh/newkey.pub scp://app
 
     and
 
     .. code:: sh
 
-      scp /home/amnesia/.ssh/newkey.pub scp://mon
+      scp -O /home/amnesia/.ssh/newkey.pub scp://mon
 
 
 #.  Add this key to the list of authorized keys.


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

This PR simply adds the "-O" flag to the scp commands used in the offboarding guide, which is now required so that it uses scp instead of trying sftp (which will result in an error).

Fixes #592

## Testing
* [ ] CI is happy
* [ ] Visual review
* [ ] Confirm command on local setup (optional, @zenmonkeykstop confirmed this originally, and I tested this as well before filing this PR)

## Release 

Can be made available in stable docs upon merge

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
