### PR TITLE
Remove uses of the word 'master' and standardize on Template Tails USB

### DIFF
--- a/docs/admin/installation/hardware.rst
+++ b/docs/admin/installation/hardware.rst
@@ -25,7 +25,7 @@ For an installation of SecureDrop, you must acquire:
   are using a desktop for the *Secure Viewing Station*).
 * A dedicated network firewall with at least 4 NICs.
 * At least 3 ethernet cables.
-* Plenty of USB sticks: 1 drive for the master Tails stick, 1 drive for each
+* Plenty of USB sticks: 1 drive for the Template Tails stick, 1 drive for each
   Secure Viewing Station, 1 drive for each *Transfer Device*, 1 drive for each
   *Export Device*, and 1 drive for each admin and journalist.
 

--- a/docs/admin/installation/passphrases.rst
+++ b/docs/admin/installation/passphrases.rst
@@ -58,8 +58,8 @@ The journalist will be using the *Journalist Workstation* with Tails to
 connect to the *Journalist Interface*. The tasks performed by the journalist
 will require the following set of passphrases:
 
--  A master passphrase for the persistent volume on the Tails device.
--  A master passphrase for the KeePassXC password manager, which unlocks
+-  A passphrase for the persistent volume on the Tails device.
+-  A passphrase for the KeePassXC password manager, which unlocks
    the passphrase for logging into the *Journalist Interface*.
 
 The journalist will also need to have a two-factor authenticator, such
@@ -77,7 +77,7 @@ The journalist will be using the *Secure Viewing Station* with Tails to
 decrypt and view submitted documents. The tasks performed by the
 journalist will require the following passphrases:
 
--  A master passphrase for the persistent volume on the Tails device.
+-  A passphrase for the persistent volume on the Tails device.
 
 The backup that is created during the installation of SecureDrop is also
 encrypted with the application's GPG key. The backup is stored on the

--- a/docs/admin/installation/set_up_admin_tails.rst
+++ b/docs/admin/installation/set_up_admin_tails.rst
@@ -220,7 +220,7 @@ After configuring the password database, restart KeePassXC once to verify
 that you are able to access it as expected.
 
 .. warning:: You will not be able to access your passwords if you
-         forget the master password or the location of the key
+         forget the peristent storage password or the location of the key
          file used to protect the database.
 
 In case you wish to manually create a database, the suggested password fields in

--- a/docs/admin/maintenance/decommission.rst
+++ b/docs/admin/maintenance/decommission.rst
@@ -69,7 +69,7 @@ SecureDrop instance.
    storage called the **LUKS header**) should be sufficient to make any existing
    data on those drives unrecoverable.
 
-   For example, you could use your *primary Tails USB* to launch Gnome Disks,
+   For example, you could use your *Template Tails USB* to launch Gnome Disks,
    insert and identify the USB drive you are trying to erase, and reformat this
    drive with a new, LUKS-encrypted partition, erasing the existing partition
    data.

--- a/docs/admin/maintenance/rebuild_admin.rst
+++ b/docs/admin/maintenance/rebuild_admin.rst
@@ -7,7 +7,7 @@ backup exists, it is possible to rebuild one. In order to do so, you'll need
  - physical access to the SecureDrop servers
  - 2 USB sticks:
 
-   - Tails Master USB
+   - Tails Template USB
    - 1 replacement *Admin Workstation* USB (USB3 and 16GB or better recommended)
 
 The process requires experience with the Linux command line and Tails, and


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR removes the word 'master' in all public-facing documentation. In most cases the term wasn't adding clarity and could be omitted entirely; in the one instance where it was descriptive, an even more precise term has been used.

As part of this work, I have standardized on "Template Tails USB" based [on this suggestion](https://github.com/freedomofpress/securedrop-docs/issues/90#issuecomment-757108697) (the other suggestion, "Reference," I thought to be too confusing in context). 

* Resolves #90

## Testing
- [ ] CI is happy
- [ ] Visual review


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
