### PR TITLE
adapt v2.10.0 upgrade guide for v2.10.1

### DIFF
--- a/docs/admin/installation/set_up_admin_tails.rst
+++ b/docs/admin/installation/set_up_admin_tails.rst
@@ -139,7 +139,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.10.0
+    git tag -v 2.10.1
 
 The output should include the following two lines:
 
@@ -160,9 +160,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.10.0
+    git checkout 2.10.1
 
-.. important:: If you see the warning ``refname '2.10.0' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.10.1' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/backup_and_restore.rst
+++ b/docs/admin/maintenance/backup_and_restore.rst
@@ -229,7 +229,7 @@ Migrating Using a V2+V3 or V3-Only Backup
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.10.0
+      git tag -v 2.10.1
 
    The output should include the following two lines:
 
@@ -250,10 +250,10 @@ Migrating Using a V2+V3 or V3-Only Backup
 
    .. code:: sh
 
-      git checkout 2.10.0
+      git checkout 2.10.1
 
    .. important::
-      If you see the warning ``refname '2.10.0' is ambiguous`` in the
+      If you see the warning ``refname '2.10.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
@@ -472,7 +472,7 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.10.0
+      git tag -v 2.10.1
 
    The output should include the following two lines:
 
@@ -491,11 +491,11 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
    .. code:: sh
 
-      git checkout 2.10.0
+      git checkout 2.10.1
 
 
    .. important::
-      If you see the warning ``refname '2.10.0' is ambiguous`` in the
+      If you see the warning ``refname '2.10.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -24,7 +24,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.10.0
+  git tag -v 2.10.1
 
 The output should include the following two lines: ::
 
@@ -37,9 +37,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.10.0
+    git checkout 2.10.1
 
-.. important:: If you do see the warning "refname '2.10.0' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.10.1' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.10.0"
+version = "2.10.1"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,6 +151,7 @@ Get Started
    :maxdepth: 2
    :hidden:
 
+   upgrade/2.10.0_to_2.10.1.rst
    upgrade/2.9.0_to_2.10.0.rst
    upgrade/2.8.0_to_2.9.0.rst
    upgrade/2.7.0_to_2.8.0.rst

--- a/docs/upgrade/2.10.0_to_2.10.1.rst
+++ b/docs/upgrade/2.10.0_to_2.10.1.rst
@@ -1,15 +1,17 @@
-Upgrade from 2.9.0 to 2.10.0
-============================
+.. _latest_upgrade_guide:
 
-Update Servers to SecureDrop 2.10.0
------------------------------------
+Upgrade from 2.10.0 to 2.10.1
+=============================
+
+Update Servers to SecureDrop 2.10.1
+------------------------------------
 
 Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop
 automatically within 24 hours of the release.
 
-Update Workstations to SecureDrop 2.10.0 and Tails 6
+Update Workstations to SecureDrop 2.10.1 and Tails 6
 ----------------------------------------------------
-If you have not already upgraded to Tails 6 alogside the 2.8.0 release,
+If you have not already upgraded to Tails 6 alogside the 2.10.0 release,
 you should do so as part of this upgrade. Please note that the upgrade
 from Tails 6 must be performed manually. If you have already upgraded
 to Tails 6, you only need to complete Step 1 below.
@@ -27,7 +29,7 @@ to Tails 6 **must** be fully performed on an air-gapped machine.
 To upgrade your *Journalist Workstation* and *Admin Workstation* USB drives,
 complete the following steps for each USB drive:
 
-1. Update to SecureDrop 2.10.0 using the graphical updater
+1. Update to SecureDrop 2.10.1 using the graphical updater
 2. Perform a manual upgrade to Tails 6
 3. Apply SecureDrop-specific configuration
 4. Verify that the workstation works as expected.
@@ -35,7 +37,7 @@ complete the following steps for each USB drive:
 These steps are further explained below. If these steps fail unexpectedly, please get
 in touch.
 
-Step 1: Update to SecureDrop 2.10.0 using the graphical updater
+Step 1: Update to SecureDrop 2.10.1 using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
@@ -43,7 +45,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.net/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.10.0 by clicking "Update Now":
+Perform the update to 2.10.1 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -63,7 +65,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.10.0
+  git tag -v 2.10.1
 
 The output should include the following two lines: ::
 
@@ -76,9 +78,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.10.0
+    git checkout 2.10.1
 
-.. important:: If you do see the warning "refname '2.10.0' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.10.1' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Towards freedomofpress/securedrop#7239.  Like v2.10.1 itself, this hews as closely as possible to v2.10.0, here based on #595.


## Testing

- [ ] Visual review, primarily for `s/2.10.0/2.10.1/g`.


## Release 

- [ ] Tag as stable for v2.10.1.


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
