### PR TITLE
Add upgrade guide for 2.11.0

### DIFF
--- a/docs/admin/installation/set_up_admin_tails.rst
+++ b/docs/admin/installation/set_up_admin_tails.rst
@@ -139,7 +139,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.10.1
+    git tag -v 2.11.0
 
 The output should include the following two lines:
 
@@ -160,9 +160,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.10.1
+    git checkout 2.11.0
 
-.. important:: If you see the warning ``refname '2.10.1' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.11.0' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/backup_and_restore.rst
+++ b/docs/admin/maintenance/backup_and_restore.rst
@@ -229,7 +229,7 @@ Migrating Using a V2+V3 or V3-Only Backup
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.10.1
+      git tag -v 2.11.0
 
    The output should include the following two lines:
 
@@ -250,10 +250,10 @@ Migrating Using a V2+V3 or V3-Only Backup
 
    .. code:: sh
 
-      git checkout 2.10.1
+      git checkout 2.11.0
 
    .. important::
-      If you see the warning ``refname '2.10.1' is ambiguous`` in the
+      If you see the warning ``refname '2.11.0' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
@@ -472,7 +472,7 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.10.1
+      git tag -v 2.11.0
 
    The output should include the following two lines:
 
@@ -491,11 +491,11 @@ source accounts, and journalist accounts. To do so, follow the steps below:
 
    .. code:: sh
 
-      git checkout 2.10.1
+      git checkout 2.11.0
 
 
    .. important::
-      If you see the warning ``refname '2.10.1' is ambiguous`` in the
+      If you see the warning ``refname '2.11.0' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -24,7 +24,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.10.1
+  git tag -v 2.11.0
 
 The output should include the following two lines: ::
 
@@ -37,9 +37,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.10.1
+    git checkout 2.11.0
 
-.. important:: If you do see the warning "refname '2.10.1' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.11.0' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.10.1"
+version = "2.11.0"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -152,6 +152,7 @@ Get Started
    :maxdepth: 2
    :hidden:
 
+   upgrade/2.10.1_to_2.11.0.rst
    upgrade/2.10.0_to_2.10.1.rst
    upgrade/2.9.0_to_2.10.0.rst
    upgrade/2.8.0_to_2.9.0.rst

--- a/docs/upgrade/2.10.0_to_2.10.1.rst
+++ b/docs/upgrade/2.10.0_to_2.10.1.rst
@@ -1,5 +1,3 @@
-.. _latest_upgrade_guide:
-
 Upgrade from 2.10.0 to 2.10.1
 =============================
 

--- a/docs/upgrade/2.10.1_to_2.11.0.rst
+++ b/docs/upgrade/2.10.1_to_2.11.0.rst
@@ -10,23 +10,13 @@ The 2.11.0 release includes a number of features that will help ensure
 your SecureDrop server is prepared for the automated migration to Ubuntu 24.04
 (Noble) in early 2025.
 
-After updating to SecureDrop 2.11.0 using the steps below, it's important
-that you review our :doc:`Ubuntu 24.04 (Noble) migration guide <../admin/maintenance/noble_migration_prep>`,
-and run the ``securedrop-noble-migration-check`` script prior to January 31st, 2025
-to ensure your server is ready for the migration.
+SecureDrop 2.11.0 will automatically run checks to ensure all servers are ready for migration to Ubuntu 24.04 (Noble). If issues are found, a banner will be displayed in the Journalist Interface to both admins and journalists. Administrators are encouraged to review the
+:doc:`Ubuntu 24.04 (Noble) migration guide <../admin/maintenance/noble_migration_prep>`
+explaining how to resolve any errors and perform any necessary steps before
+Jan. 31st, 2025.
 
 We will have more details on the migration itself early next year.
-
-.. note::
     
-    Admins and Journalists may notice a new banner after logging into the
-    *Journalist Interface*, which indicates that there are currently issues
-    that would prevent an automatic migration to Ubuntu 24.04. If you see this
-    banner, refer to the
-    :doc:`Ubuntu 24.04 (Noble) migration guide <../admin/maintenance/noble_migration_prep>`.
-    
-
-
 Update Servers to SecureDrop 2.11.0
 ------------------------------------
 
@@ -36,10 +26,8 @@ automatically within 24 hours of the release.
 Update Workstations to SecureDrop 2.11.0
 ----------------------------------------
 
-.. important:: We always recommend backing up your workstations prior to
-  an upgrade, but we *especially* recommend it before a major Tails version
-  bump. This upgrade is an excellent occasion to make sure you have fresh
-  backups for each of your Tails drives. See our :ref:`backup instructions <backup_workstations>`
+.. important:: We recommend backing up your workstations prior to
+  any upgrades. See our :ref:`backup instructions <backup_workstations>`
   for more information.
 
 Update to SecureDrop 2.11.0 using the graphical updater

--- a/docs/upgrade/2.10.1_to_2.11.0.rst
+++ b/docs/upgrade/2.10.1_to_2.11.0.rst
@@ -15,6 +15,17 @@ that you review our :doc:`Ubuntu 24.04 (Noble) migration guide <../admin/mainten
 and run the ``securedrop-noble-migration-check`` script prior to January 31st, 2025
 to ensure your server is ready for the migration.
 
+We will have more details on the migration itself early next year.
+
+.. note::
+    
+    Admins and Journalists may notice a new banner after logging into the
+    *Journalist Interface*, which indicates that there are currently issues
+    that would prevent an automatic migration to Ubuntu 24.04. If you see this
+    banner, refer to the
+    :doc:`Ubuntu 24.04 (Noble) migration guide <../admin/maintenance/noble_migration_prep>`.
+    
+
 
 Update Servers to SecureDrop 2.11.0
 ------------------------------------

--- a/docs/upgrade/2.10.1_to_2.11.0.rst
+++ b/docs/upgrade/2.10.1_to_2.11.0.rst
@@ -1,0 +1,93 @@
+.. _latest_upgrade_guide:
+
+Upgrade from 2.10.1 to 2.11.0
+=============================
+
+Preparing for the Ubuntu 24.04 (Noble) migration
+------------------------------------------------
+
+The 2.11.0 release includes a number of features that will help ensure
+your SecureDrop server is prepared for the automated migration to Ubuntu 24.04
+(Noble) in early 2025.
+
+After updating to SecureDrop 2.11.0 using the steps below, it's important
+that you review our :doc:`Ubuntu 24.04 (Noble) migration guide <../admin/maintenance/noble_migration_prep>`,
+and run the ``securedrop-noble-migration-check`` script prior to January 31st, 2025
+to ensure your server is ready for the migration.
+
+
+Update Servers to SecureDrop 2.11.0
+------------------------------------
+
+Servers running Ubuntu 20.04 will be updated to the latest version of SecureDrop
+automatically within 24 hours of the release.
+
+Update Workstations to SecureDrop 2.11.0
+----------------------------------------
+
+.. important:: We always recommend backing up your workstations prior to
+  an upgrade, but we *especially* recommend it before a major Tails version
+  bump. This upgrade is an excellent occasion to make sure you have fresh
+  backups for each of your Tails drives. See our :ref:`backup instructions <backup_workstations>`
+  for more information.
+
+Update to SecureDrop 2.11.0 using the graphical updater
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
+the *SecureDrop Workstation Updater* will alert you to workstation updates. You
+must have `configured an administrator password <https://tails.net/doc/first_steps/welcome_screen/administration_password/>`_
+on the Tails welcome screen in order to use the graphical updater.
+
+Perform the update to 2.11.0 by clicking "Update Now":
+
+.. image:: ../images/securedrop-updater.png
+
+Fallback: Perform a manual update
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If the graphical updater fails and you want to perform a manual update instead,
+first delete the graphical updater's temporary flag file, if it exists (the
+``.`` before ``securedrop`` is not a typo): ::
+
+  rm ~/Persistent/.securedrop/securedrop_update.flag
+
+This will prevent the graphical updater from attempting to re-apply the failed
+update and has no bearing on future updates. You can now perform a manual
+update by running the following commands: ::
+
+  cd ~/Persistent/securedrop
+  git fetch --tags
+  gpg --keyserver hkps://keys.openpgp.org --recv-key \
+   "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
+  git tag -v 2.11.0
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 2359E6538C0613E652955E6C188EDD3B7B22E6A3
+    gpg: Good signature from "SecureDrop Release Signing Key <securedrop-release-key-2021@freedom.press>" [unknown]
+
+
+Please verify that each character of the fingerprint above matches what is
+on the screen of your workstation. A warning that the key is not certified
+is normal and expected. If the output includes the lines above, you can check
+out the new release: ::
+
+    git checkout 2.11.0
+
+.. important:: If you do see the warning "refname '2.11.0' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Finally, run the following commands: ::
+
+  sudo apt update
+  ./securedrop-admin setup
+  ./securedrop-admin tailsconfig
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation, we are
+happy to help!
+
+.. include:: ../includes/getting-support.txt


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Description: This adds an upgrade guide for 2.11.0. Notable changes here are that it also links out to the noble migration guide, and that it no longer specifies that users should upgrade to Tails 6 (we have been advising this in each release since 2.8.0, so I decided this is no longer necessary. If others feel we should include it again, I can add it back.)

* Resolves #616

## Testing
- [ ] CI passes
- [ ] Visual review

## Release 
- [ ] To be released alongside SD 2.11.0


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
