### PR TITLE
Add note that ufw removal OSSEC alerts might be confusing

### DIFF
--- a/docs/admin/maintenance/noble_migration_prep.rst
+++ b/docs/admin/maintenance/noble_migration_prep.rst
@@ -81,6 +81,10 @@ To address it, you can run:
 
 If that emits an error, please send it to :ref:`Support <getting_support>`.
 
+.. note:: You may receive an OSSEC alert that the ``ufw`` package was installed
+   and then removed; it is a known bug and safe to ignore unless the check script
+   continues to alert you about ``ufw``.
+
 Free space
 ----------
 


### PR DESCRIPTION


## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review 


## Description of Changes

Because of an upstream OSSEC bug[1], it alerts that the "ufw" package was installed right before it alerts that it was removed.

Despite the notification, there is nothing for admins to do, so add a small note about it.

[1] https://github.com/ossec/ossec-hids/issues/2141

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* please tag a new stable docs once this is merged


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
