### PR TITLE
Fix broken Tor Proof-of-Work link

### DIFF
--- a/docs/admin/deployment/tor_pow.rst
+++ b/docs/admin/deployment/tor_pow.rst
@@ -8,7 +8,7 @@ Tor network as a whole <https://blog.torproject.org/tor-network-ddos-attack/>`_
 as well as burden individual onion services, including SecureDrops.
 
 Tor now includes a `proof-of-work (PoW) defense
-<https://community.torproject.org/onion-services/ecosystem/technology/pow/>`_
+<https://onionservices.torproject.org/technology/pow/#general-questions>`_
 against denial-of-service attacks that can be turned on for individual onion
 services.  As of SecureDrop 2.9.0, new SecureDrops have this feature enabled by
 default, and we encourage all SecureDrop administrators to turn it on for their


### PR DESCRIPTION


## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review 


## Description of Changes

* Description: The original link is a 404, so link to Tor's PoW FAQ.



## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [x] visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
