### PR TITLE
docs: warn about macOS 15 compatibility

### DIFF
--- a/docs/admin/installation/set_up_transfer_and_export_device.rst
+++ b/docs/admin/installation/set_up_transfer_and_export_device.rst
@@ -199,6 +199,15 @@ you need to install the VeraCrypt software. The `guide by Freedom of the Press
 Foundation <https://freedom.press/training/encryption-toolkit-media-makers-veracrypt-guide/>`__
 provides instructions for encrypting storage media using VeraCrypt.
 
+.. Remove the following warning once securedrop-docs#599 and
+   veracrypt/VeraCrypt#1422 are resolved.
+
+.. warning::
+
+   If you plan to use your *Export Device* with computers running macOS 15
+   ("Sequoia") or later, you must also perform the VeraCrypt setup on that
+   version of macOS.
+
 Keep in mind that each journalist using a Windows or Mac workstation will need
 to have the VeraCrypt software installed on their computer to access the encrypted
 *Export Device*.


### PR DESCRIPTION
## Status

Ready for review


## Description of Changes

Documents workaround for #599.


## Testing

I welcome feedback on this language.


## Release 

- [x] Replicate to `securedrop-workstation-docs`
    * freedomofpress/securedrop-workstation-docs#295


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
