### PR TITLE
Update focal EOL to May 2025

### DIFF
--- a/docs/admin/maintenance/noble_migration.rst
+++ b/docs/admin/maintenance/noble_migration.rst
@@ -32,7 +32,7 @@ What to know
 ------------
 
 SecureDrops are currently running the Ubuntu 20.04 (Focal) operating system that
-will stop receiving security updates in April 2025. All SecureDrops must be upgraded
+will stop receiving security updates in May 2025. All SecureDrops must be upgraded
 by then to ensure you continue receiving security patches.
 
 In the past, Administrators needed to perform a full reinstall of SecureDrop to move over


### PR DESCRIPTION


## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review 

## Description of Changes

Ubuntu has extended the EOL to the end of May per
<https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare> and other sources.

Refs <https://github.com/freedomofpress/securedrop/issues/7455>.


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* for 2.12.


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
