### PR TITLE
Explain servers will be UNREACHABLE! during noble upgrade

### DIFF
--- a/docs/admin/maintenance/noble_migration.rst
+++ b/docs/admin/maintenance/noble_migration.rst
@@ -58,6 +58,9 @@ Semi-automated upgrade
 * Wait. Every few minutes there may be progress updates, however some of the steps may take
   10-15 minutes to complete
 
+  * You will likely see messages like ``fatal: [app] UNREACHABLE! ... Data could not be sent to remote host ...``
+    followed by the line: ``...ignoring``. These are expected as the servers will reboot multiple times during the upgrade.
+
 The process will upgrade your application server first and then the monitor server.
 
 Once it finishes, you should verify you can submit tips via the Source Interface and can log into the


### PR DESCRIPTION


## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

The noble_migration playbook emits scary bold red warnings that the server is unreachable and then a quiet, faded "...ignoring".

Explain that these messages are expected because the servers are rebooting.

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* visual review

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* for 2.12


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [x] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
