### PR TITLE
Update documentation for SecureDrop 2.12.1

### DIFF
--- a/docs/admin/installation/set_up_admin_tails.rst
+++ b/docs/admin/installation/set_up_admin_tails.rst
@@ -139,7 +139,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.12.0
+    git tag -v 2.12.1
 
 The output should include the following two lines:
 
@@ -160,9 +160,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.12.0
+    git checkout 2.12.1
 
-.. important:: If you see the warning ``refname '2.12.0' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.12.1' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/backup_and_restore.rst
+++ b/docs/admin/maintenance/backup_and_restore.rst
@@ -208,7 +208,7 @@ Moving a SecureDrop instance to new hardware involves:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.12.0
+      git tag -v 2.12.1
 
    The output should include the following two lines:
 
@@ -229,10 +229,10 @@ Moving a SecureDrop instance to new hardware involves:
 
    .. code:: sh
 
-      git checkout 2.12.0
+      git checkout 2.12.1
 
    .. important::
-      If you see the warning ``refname '2.12.0' is ambiguous`` in the
+      If you see the warning ``refname '2.12.1' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).

--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -24,7 +24,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.12.0
+  git tag -v 2.12.1
 
 The output should include the following two lines: ::
 
@@ -37,9 +37,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.12.0
+    git checkout 2.12.1
 
-.. important:: If you do see the warning "refname '2.12.0' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.12.1' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.12.0"
+version = "2.12.1"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,6 +153,7 @@ Get Started
    :maxdepth: 2
    :hidden:
 
+   upgrade/2.12.0_to_2.12.1.rst
    upgrade/2.11.1_to_2.12.0.rst
    upgrade/2.11.0_to_2.11.1.rst
    upgrade/2.10.1_to_2.11.0.rst

--- a/docs/upgrade/2.12.0_to_2.12.1.rst
+++ b/docs/upgrade/2.12.0_to_2.12.1.rst
@@ -1,10 +1,14 @@
-Upgrade from 2.11.1 to 2.12.0
+.. _latest_upgrade_guide:
+
+Upgrade from 2.12.0 to 2.12.1
 =============================
+
+SecureDrop 2.12.1 is an Admin Workstation-only release, which improves the reliability of the semiautomated Ubuntu Noble upgrade when using SSH-over-Tor. 
 
 Migrating to Ubuntu 24.04 (Noble)
 ---------------------------------
 
-The SecureDrop 2.12.0 release provides the foundation necessary to safely upgrade your SecureDrop Servers to Ubuntu 24.04 (Noble), which is necessary due to the upcoming end-of-life for Ubuntu 20.04 (Focal).
+As a reminder, it is necessary to upgrade your SecureDrop Servers to Ubuntu 24.04 (Noble) due to the upcoming end-of-life for Ubuntu 20.04 (Focal).
 
 Administrators have two options, on the following timeline:
 
@@ -13,20 +17,19 @@ Administrators have two options, on the following timeline:
 
 To determine which option is best for you, and to learn more about how the upgrade works, please review the :doc:`Ubuntu 24.04 (Noble) migration guide <../admin/maintenance/noble_migration>` at your earliest convenience.
     
-Update Servers to SecureDrop 2.12.0
-------------------------------------
+Servers to Remain on 2.12.0
+---------------------------
 
-Servers will be updated to the latest version of SecureDrop
-automatically within 24 hours of the release. Please note, upgrading to SecureDrop 2.12.0 does not automatically upgrade your server to Ubuntu 24.04.
+As this is an Admin Workstation-only release, servers will not receive an update and will remain on version 2.12.0. Please note, upgrading to SecureDrop 2.12.0 does not automatically upgrade your server to Ubuntu 24.04.
 
-Update Workstations to SecureDrop 2.12.0
+Update Workstations to SecureDrop 2.12.1
 ----------------------------------------
 
 .. important:: We recommend backing up your workstations prior to
   any upgrades. See our :ref:`backup instructions <backup_workstations>`
   for more information.
 
-Update to SecureDrop 2.12.0 using the graphical updater
+Update to SecureDrop 2.12.1 using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
@@ -34,7 +37,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.net/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.12.0 by clicking "Update Now":
+Perform the update to 2.12.1 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -54,7 +57,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.12.0
+  git tag -v 2.12.1
 
 The output should include the following two lines: ::
 
@@ -67,9 +70,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.12.0
+    git checkout 2.12.1
 
-.. important:: If you do see the warning "refname '2.12.0' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.12.1' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

This PR bumps version numbers and adds an upgrade guide for 2.12.1


## Testing
* [ ] With this being an Admin Workstation-only release, some of the template has been modified. Please make sure these changes are OK.
* [ ] CI is happy
* [ ] Visual review

## Release 

We will need to tag a stable docs release alongside SecureDrop 2.12.1

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
