### PR TITLE
Recommend viewing journalctl logs in reverse order

### DIFF
--- a/docs/admin/maintenance/noble_migration.rst
+++ b/docs/admin/maintenance/noble_migration.rst
@@ -106,8 +106,8 @@ Technical details and debugging
 -------------------------------
 
 If something goes wrong, logs can be seen by logging into the servers and
-running ``sudo journalctl -u securedrop-noble-migration-upgrade``. If the error isn't clear,
-:ref:`please contact us<Getting Support>`.
+running ``sudo journalctl -r -u securedrop-noble-migration-upgrade``. This will show the logs in reverse chronological order,
+so any relevant error messages should be near the top. If the error isn't clear, :ref:`please contact us<Getting Support>`.
 
 When upgrading the app server, a backup is taken first and stored at ``/var/lib/securedrop-backup``.
 If necessary, this backup can be used to do a fresh install.


### PR DESCRIPTION


## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

Recommend viewing journalctl logs in reverse order so that way the error is at the top.


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] visual review
* [x] I already tested that `-r` works as expected

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* n/a


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
