### PR TITLE
Install version-pinned Poetry via Pip

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,16 +1,34 @@
 FROM debian:bookworm AS sphinx
 
 ARG GIT_BRANCH=main
-RUN apt-get -q update && apt-get -qy upgrade && apt-get -qy install git make latexmk texlive-latex-extra python3-poetry
-COPY ./ .
-RUN poetry install
+RUN apt-get -q update && \
+    apt-get -qy upgrade && \
+    apt-get -qy install \
+      git \
+      make \
+      latexmk \
+      texlive-latex-extra \
+      python3 \
+      python3-venv
+
+# Create a dedicated venv for Poetry and install pinned version compatible with Dependabot
+RUN python3 -m venv /opt/poetry-venv
+RUN /opt/poetry-venv/bin/pip install --upgrade pip && \
+    /opt/poetry-venv/bin/pip install "poetry==2.1.2"
+
+# Make the 'poetry' command available system-wide so Makefile targets work
+RUN ln -s /opt/poetry-venv/bin/poetry /usr/local/bin/poetry
+
+COPY . .
+RUN poetry install --no-root
 RUN deploy/build $GIT_BRANCH
 
-# sha256 as of 2024-06-10
-FROM nginx:mainline-alpine-slim@sha256:244d37691a469d45349d9f29e8b7462d9f510b70c0c93acc5d23ee227070c962
+# sha256 as of 2025-02-14 image
+FROM nginx:mainline-alpine-slim@sha256:b05aceb5ec1844435cae920267ff9949887df5b88f70e11d8b2871651a596612
 
 COPY deploy/nginx.conf /etc/nginx
-RUN mkdir -p /opt/nginx/run /opt/nginx/webroot/en/latest /opt/nginx/webroot/en/stable && chown -R nginx:nginx /opt/nginx
+RUN mkdir -p /opt/nginx/run /opt/nginx/webroot/en/latest /opt/nginx/webroot/en/stable && \
+    chown -R nginx:nginx /opt/nginx
 
 USER nginx
 COPY --from=sphinx --chown=nginx:nginx build/stable/html/html/ /opt/nginx/webroot/en/stable/


### PR DESCRIPTION
This is to ensure that we can stay in sync with the version used by Dependabot

Also bumps Alpine image.

## Status

Ready for review

## Description of Changes

Installs Poetry itself via pip, as opposed to Debian package. Poetry's Debian package tends to get stale quickly (Bookworm has 1.3.2 from ~2022), while Dependabot has been quicker to update, which can lead to lockfile formats falling out of sync.  Pinning to a fixed version number avoids this issue (with the downside that we'll have to manually bump the version in case of security issues in Poetry itself).