### PR TITLE
Move to Debian Trixie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     # We use a standard Debian image to mirror a typical developer environment.
     # This should be updated whenever a new Debian stable version is available.
-    container: debian:bookworm
+    container: debian:trixie
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     # We use a standard Debian image to mirror a typical developer environment.
     # This should be updated whenever a new Debian stable version is available.
-    container: debian:bookworm
+    container: debian:trixie
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm AS sphinx
+FROM debian:trixie AS sphinx
 
 ARG GIT_BRANCH=main
 RUN apt-get -q update && apt-get -qy upgrade && apt-get -qy install git make latexmk texlive-latex-extra python3-poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
 name = "securedrop-docs"
-version = "2.7.0"
 description = "SecureDrop documentation for journalists, sources and administrators"
 authors = ["SecureDrop team <securedrop@freedom.press>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
As of this writing, it is still pre-release, but stable enough for documentation repos. This also gives us a more recent version of Poetry, which in turn allows us to disable package-mode, and mitigats lockfile format drift with Dependabot.


## Status

Ready for review

## Description of Changes

Resolves #580

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
- [x] Have also built Docker image locally
