### PR TITLE
Add docs for SecureDrop 2.12.2

### DIFF
--- a/docs/admin/installation/set_up_admin_tails.rst
+++ b/docs/admin/installation/set_up_admin_tails.rst
@@ -139,7 +139,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.12.1
+    git tag -v 2.12.2
 
 The output should include the following two lines:
 
@@ -160,9 +160,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.12.1
+    git checkout 2.12.2
 
-.. important:: If you see the warning ``refname '2.12.1' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.12.2' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/backup_and_restore.rst
+++ b/docs/admin/maintenance/backup_and_restore.rst
@@ -208,7 +208,7 @@ Moving a SecureDrop instance to new hardware involves:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.12.1
+      git tag -v 2.12.2
 
    The output should include the following two lines:
 
@@ -229,10 +229,10 @@ Moving a SecureDrop instance to new hardware involves:
 
    .. code:: sh
 
-      git checkout 2.12.1
+      git checkout 2.12.2
 
    .. important::
-      If you see the warning ``refname '2.12.1' is ambiguous`` in the
+      If you see the warning ``refname '2.12.2' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).

--- a/docs/admin/maintenance/noble_migration.rst
+++ b/docs/admin/maintenance/noble_migration.rst
@@ -5,18 +5,14 @@ SecureDrops need to be upgraded to the newer Ubuntu 24.04 (Noble)
 operating system. This process is far simpler than past upgrades
 as it has been fully automated.
 
-Administrators have two options, on the following timeline:
+Current status
+--------------
 
-* **semiautomated, through April 15, 2025:** Administrators can manually trigger the upgrade and observe the process.
-* **fully automated, after April 15, 2025:** The SecureDrop team will push updates through mid- to late-April that automatically trigger the upgrade process, in phases, across all SecureDrop instances.
+As of April 22nd, 2025, 20% of all *Application Servers* are being automatically upgraded.
 
-The fully automated upgrade is the simplest option, as it requires no action on your part.
+You can still manually trigger a semiautomated upgrade to Noble. We still recommend the semiautomated upgrade for larger instances or if you have a non-standard setup, as the upgrade will happen whenever you choose so you will already be available in case something goes wrong during the process.
 
-We recommend the semiautomated upgrade for larger instances or if you have a non-standard setup as
-the upgrade will happen whenever you choose it, so you will already be available in case something goes
-wrong during the process.
-
-.. warning:: If you are using not using `recommended hardware <../installation/hardware.html#specific-hardware-recommendations>`_ for your *Application* and *Monitor Servers*, we strongly recommend doing a semiautomated upgrade **before** April 15th, 2025. 
+.. warning:: If you are using not using `recommended hardware <../installation/hardware.html#specific-hardware-recommendations>`_ for your *Application* and *Monitor Servers*, we strongly recommend doing a semiautomated upgrade.
 
 Preparation
 -----------
@@ -92,8 +88,7 @@ Repeat it for the *Monitor Server* too:
 Fully automated upgrade
 -----------------------
 
-If you have not performed the semiautomated upgrade by March 21, 2025, the SecureDrop team
-will push an update that begins an automated upgrade. This is the same code as the semiautomated
+We are currently in the automated upgrade phase. This is the same code as the semiautomated
 process, just initiated differently.
 
 Servers will be upgraded in batches at a pace set by the SecureDrop team.

--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -24,7 +24,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.12.1
+  git tag -v 2.12.2
 
 The output should include the following two lines: ::
 
@@ -37,9 +37,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.12.1
+    git checkout 2.12.2
 
-.. important:: If you do see the warning "refname '2.12.1' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.12.2' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.12.1"
+version = "2.12.2"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,6 +153,7 @@ Get Started
    :maxdepth: 2
    :hidden:
 
+   upgrade/2.12.1_to_2.12.2.rst
    upgrade/2.12.0_to_2.12.1.rst
    upgrade/2.11.1_to_2.12.0.rst
    upgrade/2.11.0_to_2.11.1.rst

--- a/docs/upgrade/2.12.1_to_2.12.2.rst
+++ b/docs/upgrade/2.12.1_to_2.12.2.rst
@@ -1,33 +1,23 @@
-Upgrade from 2.12.0 to 2.12.1
-=============================
+.. _latest_upgrade_guide:
 
-SecureDrop 2.12.1 is an Admin Workstation-only release, which improves the reliability of the semiautomated Ubuntu Noble upgrade when using SSH-over-Tor. 
+Upgrade from 2.12.1 to 2.12.2
+=============================
 
 Migrating to Ubuntu 24.04 (Noble)
 ---------------------------------
 
-As a reminder, it is necessary to upgrade your SecureDrop Servers to Ubuntu 24.04 (Noble) due to the upcoming end-of-life for Ubuntu 20.04 (Focal).
+Following a successful period of semiautomated migrations to Ubuntu Noble, we are beginning the first phase of automated upgrades. Approximately 20% of *Application Servers* will be automatically upgraded.
 
-Administrators have two options, on the following timeline:
+If you receive :doc:`pre-upgrade error notifications <../admin/maintenance/noble_migration_prep>` from OSSEC, please review our :doc:`Noble upgrade guide <../admin/maintenance/noble_migration>`.
 
-* **semiautomated, through April 15, 2025:** Administrators can manually trigger the upgrade and observe the process.
-* **fully automated, after April 15, 2025:** The SecureDrop team will push an update in mid- to late-April that automatically begins the upgrade process on all servers.
-
-To determine which option is best for you, and to learn more about how the upgrade works, please review the :doc:`Ubuntu 24.04 (Noble) migration guide <../admin/maintenance/noble_migration>` at your earliest convenience.
-    
-Servers to Remain on 2.12.0
----------------------------
-
-As this is an Admin Workstation-only release, servers will not receive an update and will remain on version 2.12.0. Please note, upgrading to SecureDrop 2.12.0 does not automatically upgrade your server to Ubuntu 24.04.
-
-Update Workstations to SecureDrop 2.12.1
+Update Workstations to SecureDrop 2.12.2
 ----------------------------------------
 
 .. important:: We recommend backing up your workstations prior to
   any upgrades. See our :ref:`backup instructions <backup_workstations>`
   for more information.
 
-Update to SecureDrop 2.12.1 using the graphical updater
+Update to SecureDrop 2.12.2 using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
@@ -35,7 +25,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.net/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.12.1 by clicking "Update Now":
+Perform the update to 2.12.2 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -55,7 +45,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.12.1
+  git tag -v 2.12.2
 
 The output should include the following two lines: ::
 
@@ -68,9 +58,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.12.1
+    git checkout 2.12.2
 
-.. important:: If you do see the warning "refname '2.12.1' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.12.2' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 


### PR DESCRIPTION
## Status
Ready for review

## Description of Changes

Bumps the version number and adds an upgrade guide for the SecureDrop 2.12.2 release

## Testing
- [ ] Visual review
- [ ] CI passes

## Release 

To be tagged in a stable docs update alongside 2.12.2 release


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
