### PR TITLE
Add 2.12.3 release docs

### DIFF
--- a/docs/admin/installation/set_up_admin_tails.rst
+++ b/docs/admin/installation/set_up_admin_tails.rst
@@ -139,7 +139,7 @@ signed with the release signing key:
 
     cd ~/Persistent/securedrop/
     git fetch --tags
-    git tag -v 2.12.2
+    git tag -v 2.12.3
 
 The output should include the following two lines:
 
@@ -160,9 +160,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.12.2
+    git checkout 2.12.3
 
-.. important:: If you see the warning ``refname '2.12.2' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.12.3' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/admin/maintenance/backup_and_restore.rst
+++ b/docs/admin/maintenance/backup_and_restore.rst
@@ -208,7 +208,7 @@ Moving a SecureDrop instance to new hardware involves:
 
       cd ~/Persistent/securedrop/
       git fetch --tags
-      git tag -v 2.12.2
+      git tag -v 2.12.3
 
    The output should include the following two lines:
 
@@ -229,10 +229,10 @@ Moving a SecureDrop instance to new hardware involves:
 
    .. code:: sh
 
-      git checkout 2.12.2
+      git checkout 2.12.3
 
    .. important::
-      If you see the warning ``refname '2.12.2' is ambiguous`` in the
+      If you see the warning ``refname '2.12.3' is ambiguous`` in the
       output, we recommend that you contact us immediately at
       securedrop@freedom.press
       (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).

--- a/docs/admin/maintenance/noble_migration.rst
+++ b/docs/admin/maintenance/noble_migration.rst
@@ -8,7 +8,7 @@ as it has been fully automated.
 Current status
 --------------
 
-As of April 22nd, 2025, 20% of all *Application Servers* are being automatically upgraded.
+As of April 28th, 2025, 40% of all *Application Servers* are being automatically upgraded.
 
 You can still manually trigger a semiautomated upgrade to Noble. We still recommend the semiautomated upgrade for larger instances or if you have a non-standard setup, as the upgrade will happen whenever you choose so you will already be available in case something goes wrong during the process.
 

--- a/docs/admin/maintenance/update_workstations.rst
+++ b/docs/admin/maintenance/update_workstations.rst
@@ -24,7 +24,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.12.2
+  git tag -v 2.12.3
 
 The output should include the following two lines: ::
 
@@ -37,9 +37,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.12.2
+    git checkout 2.12.3
 
-.. important:: If you do see the warning "refname '2.12.2' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.12.3' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.12.2"
+version = "2.12.3"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,6 +153,7 @@ Get Started
    :maxdepth: 2
    :hidden:
 
+   upgrade/2.12.2_to_2.12.3.rst
    upgrade/2.12.1_to_2.12.2.rst
    upgrade/2.12.0_to_2.12.1.rst
    upgrade/2.11.1_to_2.12.0.rst

--- a/docs/upgrade/2.12.2_to_2.12.3.rst
+++ b/docs/upgrade/2.12.2_to_2.12.3.rst
@@ -1,21 +1,25 @@
-Upgrade from 2.12.1 to 2.12.2
+.. _latest_upgrade_guide:
+
+Upgrade from 2.12.2 to 2.12.3
 =============================
 
 Migrating to Ubuntu 24.04 (Noble)
 ---------------------------------
 
-Following a successful period of semiautomated migrations to Ubuntu Noble, we are beginning the first phase of automated upgrades. Approximately 20% of *Application Servers* will be automatically upgraded.
+After an initial set of successfully fully automated upgrades to Ubuntu 24.04 (Noble) with the 2.12.2 release, we are now enabling the next batch of automated uprades. In practice, this will result in approximately 40% of *Application Servers* being upgraded.
 
 If you receive :doc:`pre-upgrade error notifications <../admin/maintenance/noble_migration_prep>` from OSSEC, please review our :doc:`Noble upgrade guide <../admin/maintenance/noble_migration>`.
 
-Update Workstations to SecureDrop 2.12.2
+This release also addresses an issue where some SecureDrop instances that failed the pre-upgrade migration check could remain in a state with automatic updates disabled. The SecureDrop team is monitoring known servers; if we believe this bug as affected you, we will reach out with steps to re-enable automatic updates.
+
+Update Workstations to SecureDrop 2.12.3
 ----------------------------------------
 
 .. important:: We recommend backing up your workstations prior to
   any upgrades. See our :ref:`backup instructions <backup_workstations>`
   for more information.
 
-Update to SecureDrop 2.12.2 using the graphical updater
+Update to SecureDrop 2.12.3 using the graphical updater
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
@@ -23,7 +27,7 @@ the *SecureDrop Workstation Updater* will alert you to workstation updates. You
 must have `configured an administrator password <https://tails.net/doc/first_steps/welcome_screen/administration_password/>`_
 on the Tails welcome screen in order to use the graphical updater.
 
-Perform the update to 2.12.2 by clicking "Update Now":
+Perform the update to 2.12.3 by clicking "Update Now":
 
 .. image:: ../images/securedrop-updater.png
 
@@ -43,7 +47,7 @@ update by running the following commands: ::
   git fetch --tags
   gpg --keyserver hkps://keys.openpgp.org --recv-key \
    "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
-  git tag -v 2.12.2
+  git tag -v 2.12.3
 
 The output should include the following two lines: ::
 
@@ -56,9 +60,9 @@ on the screen of your workstation. A warning that the key is not certified
 is normal and expected. If the output includes the lines above, you can check
 out the new release: ::
 
-    git checkout 2.12.2
+    git checkout 2.12.3
 
-.. important:: If you do see the warning "refname '2.12.2' is ambiguous" in the
+.. important:: If you do see the warning "refname '2.12.3' is ambiguous" in the
   output, we recommend that you contact us immediately at securedrop@freedom.press
   (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

* Bumps the version numbers
* Adds an upgrade guide, including advisories from the upcoming blog post

## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
* [ ] CI passes
* [ ] Visual review

## Release 

Stable docs need to be tagged alongside SecureDrop 2.12.3 release


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
