### PR TITLE
Bump Noble upgrade status to 60%

### DIFF
--- a/docs/admin/maintenance/noble_migration.rst
+++ b/docs/admin/maintenance/noble_migration.rst
@@ -8,7 +8,7 @@ as it has been fully automated.
 Current status
 --------------
 
-As of April 28th, 2025, 40% of all *Application Servers* are being automatically upgraded.
+As of April 30th, 2025, 60% of all *Application Servers* are being automatically upgraded.
 
 You can still manually trigger a semiautomated upgrade to Noble. We still recommend the semiautomated upgrade for larger instances or if you have a non-standard setup, as the upgrade will happen whenever you choose so you will already be available in case something goes wrong during the process.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

A one-liner to bump the Noble upgrade status number to 60% of Application Servers

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
