### PR TITLE
Clarify that Tor Browser security setting may interfere with QR code display

### DIFF
--- a/docs/admin/reference/admin_interface.rst
+++ b/docs/admin/reference/admin_interface.rst
@@ -85,6 +85,8 @@ If two-factor authentication was set up successfully, you will be redirected bac
 to the *Admin Interface* and will see a confirmation that the two-factor code was
 verified.
 
+.. include:: ../../includes/tor-security-setting.txt
+
 YubiKey
 ~~~~~~~
 
@@ -184,7 +186,7 @@ You should see a message appear indicating the change was a success.
 
 |Logo Update|
 
-It may be necessary to hold the Shift key while pressing the Reload button in 
+It may be necessary to hold the Shift key while pressing the Reload button in
 the browser, which will force it to purge the cached version of the logo
 in order to see the new one.
 

--- a/docs/includes/tor-security-setting.txt
+++ b/docs/includes/tor-security-setting.txt
@@ -1,0 +1,6 @@
+.. note::
+
+   If the QR code for setting up two-factor authentication in your mobile authenticator app is not
+   displayed, it may be blocked by Tor Browser. You can set Tor Browser's security level to
+   **Standard** by clicking on the Shield icon. Alternatively, you can manually type in the
+   two-factor secret (in FreeOTP, use the **Add token** option from the menu).

--- a/docs/journalist/workstation.rst
+++ b/docs/journalist/workstation.rst
@@ -96,6 +96,8 @@ admin for assistance.
 
 |Journalist account profile|
 
+.. include:: ../includes/tor-security-setting.txt
+
 .. _daily_journalist_alerts:
 
 


### PR DESCRIPTION
Resolves https://github.com/freedomofpress/securedrop/issues/3291

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
