### PR TITLE
Bump Noble upgrade status to 100% for App and Mon

### DIFF
--- a/docs/admin/maintenance/noble_migration.rst
+++ b/docs/admin/maintenance/noble_migration.rst
@@ -8,7 +8,7 @@ as it has been fully automated.
 Current status
 --------------
 
-As of May 7th, 2025, 100% of *Application Servers* and approximately 40% of *Monitor Servers* are being automatically upgraded.
+As of May 8th, 2025, 100% of *Application* and *Monitor Servers* are being automatically upgraded.
 
 You can still manually trigger a semiautomated upgrade to Noble. We still recommend the semiautomated upgrade for larger instances or if you have a non-standard setup, as the upgrade will happen whenever you choose so you will already be available in case something goes wrong during the process.
 


### PR DESCRIPTION
## Status

Ready for Review

## Description of Changes

This reports that 100% of App and Mon servers are being automatically upgraded.

I debated whether to take out/rework the "semiautomated upgrades are still available" portion, but since that's still true until everyone grabs the update, I figured it best to leave it for now and modify when appropriate.

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
