### PR TITLE
Update references to Ubuntu version in servers.rst

### DIFF
--- a/docs/admin/installation/servers.rst
+++ b/docs/admin/installation/servers.rst
@@ -23,7 +23,7 @@ hardware, including:
 
 In most cases, you should enable support for LAN and USB ports only.
 
-You should also check the servers' boot settings. Ubuntu 20.04 supports both
+You should also check the servers' boot settings. Ubuntu 24.04 supports both
 Legacy and UEFI boot modes, with UEFI preferred. You should also disable Secure
 Boot. SecureDrop uses a custom kernel with security patches, which is unsigned
 and will not boot if Secure Boot is enabled.
@@ -36,8 +36,7 @@ enumerate recommended BIOS settings for hardware that we have tested.
 Install Ubuntu
 ---------------
 
-The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu Server
-20.04.6 LTS (Focal Fossa)**. To install Ubuntu on the servers, you must first
+The SecureDrop *Application Server* and *Monitor Server* run **Ubuntu 24.04.2 LTS (Noble Numbat)**. To install Ubuntu on the servers, you must first
 download and verify the Ubuntu installation media.
 
 You should have already performed this step while setting up the Tails USB


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Description: 
Fixes 2 stale references to Ubuntu Focal in the server installation instructions. 

* Resolves #679 
<!-- Add an issue number immediately after the # symbol to link to an existing issue report --> 

* Related Issues
<!-- List any other unresolved, but relevant issues that this PR addresses -->


## Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
*

## Release 
<!-- Any special considerations for release of this change into the stable version of the documentation? -->
* 


## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
