### PR TITLE
Update hardware EOL changes

### DIFF
--- a/docs/admin/installation/hardware.rst
+++ b/docs/admin/installation/hardware.rst
@@ -748,8 +748,8 @@ Hardware             End-of-Life (EOL)
 ===================  ====================================================
 ASUS NUC14RVH        Not yet confirmed
 ASUS NUC13ANHi5      Not yet confirmed
-Intel NUC12WSKi5     Not yet confirmed
-Intel NUC11PAHi3     June 30, 2025                                       
+Intel NUC12WSKi5     April 05, 2026
+Intel NUC11PAHi3     September 30, 2026                                       
 Intel NUC10i5FNH     June 25, 2024                                       
 Intel NUC8i5BEK      March 26, 2024                                      
 Intel NUC7i5BNH      April 30, 2023                                      


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR was originally going to document that the NUC 11 is EOL, but thanks to changes in the actual EOL date from Asus' acquisition of the NUC line from Intel, it actually just updates the EOL date table with the change to the NUC11 date, and adds a previously unknown date.

* Resolves #692

## Testing
* [ ] Visual review
* [ ] CI is happy

## Release 

Can be released any time

## Checklist (Optional)

- [ ] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [ ] You have previewed (`make docs`) docs at http://localhost:8000
