### PR TITLE
update ssh restart command for Noble

### DIFF
--- a/docs/admin/maintenance/rebuild_admin.rst
+++ b/docs/admin/maintenance/rebuild_admin.rst
@@ -165,7 +165,7 @@ and deleting the line:
 
   PasswordAuthentication no
 
-Restart ``sshd`` using the command ``sudo service sshd restart``.
+Restart ``sshd`` using the command ``sudo systemctl restart ssh``.
 
 Then, use the command ``ip a`` to note the local IP address of the
 default Ethernet interface. You'll need it in the next step.
@@ -188,7 +188,7 @@ First, log on to the *Application Server* via the console and edit the file
 
   PasswordAuthentication no
 
-Restart ``sshd`` using the command ``sudo service sshd restart``.
+Restart ``sshd`` using the command ``sudo systemctl restart ssh``.
 
 Then, use the command ``ip a`` to note the local IP address for the
 default Ethernet interface. You'll need it in the next step.


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review 

## Description of Changes

* Description: 
Fixes the command to restart `ssh` in accordance with Ubuntu 24.04's change in how sshd is managed by systemd. The `service` command is also replaced with `systemctl`.

* Resolves #698
<!-- Add an issue number immediately after the # symbol to link to an existing issue report --> 

## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
