### PR TITLE
Service to systemctl

### DIFF
--- a/docs/admin/maintenance/logging.rst
+++ b/docs/admin/maintenance/logging.rst
@@ -50,7 +50,7 @@ sense to temporarily enable error logging. To do so:
    ErrorLog /var/log/apache2/source-error.log
    LogLevel debug
 
-5. Save the file and reload the configuration with ``sudo service apache2 reload``
+5. Save the file and reload the configuration with ``sudo systemctl reload apache2``
 6. Visit the Source Interface and reproduce the error
 7. Inspect the log file ``/var/log/apache2/source-error.log`` for any details
 8. Remember to set the configuration back to the default values once your

--- a/docs/admin/maintenance/ossec_alerts.rst
+++ b/docs/admin/maintenance/ossec_alerts.rst
@@ -259,7 +259,7 @@ Some OSSEC alerts should begin to arrive as soon as the installation has
 finished.
 
 The easiest way to test that OSSEC is working is to SSH to the Monitor
-Server and run ``service ossec restart``. This will trigger an Alert
+Server and run ``systemctl restart ossec``. This will trigger an Alert
 level 3 saying: "Ossec server started."
 
 So you've finished installing SecureDrop, but you haven't received any
@@ -292,7 +292,7 @@ Authentication failure           | Edit ``/etc/postfix/sasl_passwd`` and make
 ================================ ===================================================
 
 After making changes to the Postfix configuration, you should run
-``service postfix reload`` and test the new settings by restarting the
+``systemctl reload postfix`` and test the new settings by restarting the
 OSSEC service.
 
 .. tip:: If you change the SMTP relay port after installation for any

--- a/docs/admin/maintenance/rebuild_admin.rst
+++ b/docs/admin/maintenance/rebuild_admin.rst
@@ -165,7 +165,7 @@ and deleting the line:
 
   PasswordAuthentication no
 
-Restart ``sshd`` using the command ``sudo service sshd restart``.
+Restart ``sshd`` using the command ``sudo systemctl restart ssh``.
 
 Then, use the command ``ip a`` to note the local IP address of the
 default Ethernet interface. You'll need it in the next step.
@@ -188,7 +188,7 @@ First, log on to the *Application Server* via the console and edit the file
 
   PasswordAuthentication no
 
-Restart ``sshd`` using the command ``sudo service sshd restart``.
+Restart ``sshd`` using the command ``sudo systemctl restart ssh``.
 
 Then, use the command ``ip a`` to note the local IP address for the
 default Ethernet interface. You'll need it in the next step.

--- a/docs/admin/reference/ssh_access.rst
+++ b/docs/admin/reference/ssh_access.rst
@@ -114,7 +114,7 @@ web server to apply the changes:
 
 .. code:: sh
 
-  sudo service apache2 restart
+  sudo systemctl restart apache2
 
 .. _submission-cleanup:
 


### PR DESCRIPTION
## Status
<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->

Ready for review


## Description of Changes

* Description: 
Updates the command to restart ssh (as in PR 700 https://github.com/freedomofpress/securedrop-docs/pull/700), and additionally replaces all instances throughout the docs of the `service` command with the equivalent `systemctl` command.

* Resolves #698
Speficically this comment from @legoktm https://github.com/freedomofpress/securedrop-docs/issues/698#issuecomment-3052872296 applied to the rest of the documentation.
<!-- Add an issue number immediately after the # symbol to link to an existing issue report --> 


## Checklist (Optional)

- [x] Doc linting (`make docs-lint`) passed locally
- [ ] Doc link linting (`make docs-linkcheck`) passed
- [x] You have previewed (`make docs`) docs at http://localhost:8000
