### PR TITLE
Simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,9 @@
-## Status
-<!-- What state is your PR in? Select one of the following and delete the option that does not apply. -->
+Fixes #
 
-Ready for review / Work in progress
+## Test plan
+<!--Any instructions the reviewer should reproduce? Otherwise, delete this section. -->
 
+## Checklist
 
-## Description of Changes
-
-* Description: 
-
-* Resolves #
-<!-- Add an issue number immediately after the # symbol to link to an existing issue report --> 
-
-* Related Issues
-<!-- List any other unresolved, but relevant issues that this PR addresses -->
-
-
-## Testing
-<!-- How should the reviewer test this PR? Write out any special testing steps here. -->
-*
-
-## Release 
-<!-- Any special considerations for release of this change into the stable version of the documentation? -->
-* 
-
-
-## Checklist (Optional)
-
-- [ ] Doc linting (`make docs-lint`) passed locally
-- [ ] Doc link linting (`make docs-linkcheck`) passed
-- [ ] You have previewed (`make docs`) docs at http://localhost:8000
+This change accounts for:
+- [ ] local preview of changes beyond typo-level edits


### PR DESCRIPTION
Same principles as https://github.com/freedomofpress/securedrop/blob/develop/.github/PULL_REQUEST_TEMPLATE.md

- Use project board to track state
- "Description" is implied
- Trust in CI to tell us about failing tests or checks
- When a checklist is not completed, that should always convey useful information