### PR TITLE
Build a 2.12 version of docs

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,3 +17,5 @@ COPY --from=sphinx --chown=nginx:nginx build/stable/html/html/ /opt/nginx/webroo
 COPY --from=sphinx --chown=nginx:nginx build/stable/html/latex/SecureDrop.pdf /opt/nginx/webroot/en/stable/
 COPY --from=sphinx --chown=nginx:nginx build/latest/html/html/ /opt/nginx/webroot/en/latest/
 COPY --from=sphinx --chown=nginx:nginx build/latest/html/latex/SecureDrop.pdf /opt/nginx/webroot/en/latest/
+COPY --from=sphinx --chown=nginx:nginx build/2.12/html/html/ /opt/nginx/webroot/en/2.12/
+COPY --from=sphinx --chown=nginx:nginx build/2.12/html/latex/SecureDrop.pdf /opt/nginx/webroot/en/2.12/

--- a/deploy/build
+++ b/deploy/build
@@ -7,6 +7,7 @@ set -e
 
 
 stable_tag=$(git tag --sort=version:refname | tail -1)
+two_twelve_tag=$(git tag --sort=version:refname | grep "2.12" | tail -1)
 
 do_build() {
     git checkout "$1"
@@ -21,4 +22,5 @@ do_build() {
 }
 
 do_build "$stable_tag" stable
+do_build "$two_twelve_tag" 2.12
 do_build "$1" latest

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -20,6 +20,9 @@
             <dd{% if release == "latest" %} class="current-release"{% endif %}>
                 <a href="/en/latest/{{ pagename }}.html">latest</a>
             </dd>
+            <dd{% if release == "2.12" %} class="current-release"{% endif %}>
+                <a href="/en/2.12/{{ pagename }}.html">2.12</a>
+            </dd>
         </dl>
         <dl>
             <dt>Downloads</dt>


### PR DESCRIPTION
Since the 2.13.0 docs will be very different, keep a version of the old docs around for reference in case people need to fix things before they upgrade.

This will use the latest 2.12.x tag in case future updates/fixes need to be made to that branch.

## Test plan
<!--Any instructions the reviewer should reproduce? Otherwise, delete this section. -->
* [x] Run `podman build --build-arg GIT_BRANCH=$(git rev-parse HEAD) --file ./deploy/Dockerfile . -t sd-docs`
* [x] Then `podman run -p 5080:5080 --rm sd-docs`
* [x] Now visit http://localhost:5080/en/2.12/ which should be a 2.12.x build. You can verify it has older content by checking http://localhost:5080/en/2.12/getting_support.html which should still reference the Support Portal and not Signal yet.

## Checklist

This change accounts for:
- [x] local preview of changes beyond typo-level edits