### PR TITLE
added "install every time" note + instruction to reboot

### DIFF
--- a/docs/upgrade/2.12.10_to_2.13.0.rst
+++ b/docs/upgrade/2.12.10_to_2.13.0.rst
@@ -75,6 +75,99 @@ Next, run the following commands: ::
   sudo apt update
   ./securedrop-admin setup
 
+.. note:: The apt persistence feature will prompt to install the package
+          automatically from persistent storage on each boot. Click
+          **Install Every Time**:
+
+          |Tails Apt Persistence|
+
+When the `./securedrop-admin setup` command has completed, reboot the the workstation to complete the upgrade. 
+
+Getting Support
+---------------
+
+Should you require further support with your SecureDrop installation, we are
+happy to help!
+
+.. include:: ../includes/getting-support.txt
+.. |Tails Apt Persistence| image:: ../images/tails-install-once-or-every-time.png
+
+Upgrade from 2.12.10 to 2.13.0
+==============================
+
+Changes in SecureDrop 2.13.0
+----------------------------
+
+SecureDrop 2.13.10 marks a major change from previous versions: the ``securedrop-admin`` tool is now provided as a Debian package installed on Tails using ``apt`` and available system-wide, instead of being run directly from a cloned version of the SecureDrop Git repository. 
+
+Some key changes you should be aware of:
+
+- The ``~/Persistent/securedrop`` directory is no longer used. 
+- The ``securedrop-admin`` utility is installed in the default path and can be run as ``securedrop-admin <command>`` in a terminal window.
+- Configuration and backup files will now be stored in ``~/.config/securedrop-admin``.
+- The GUI updater is no longer required.
+
+For more details, see the `announcement for this release <https://securedrop.org/news/securedrop-2_13_0-released/>`_. 
+
+Update Workstations to SecureDrop 2.13.0
+----------------------------------------
+
+.. important:: We recommend backing up your workstations prior to
+  any upgrades. See our :ref:`backup instructions <backup_workstations>`
+  for more information.
+
+Update to SecureDrop 2.13.10 using the graphical updater
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On the next boot of your SecureDrop *Journalist* and *Admin Workstations*,
+the *SecureDrop Workstation Updater* will alert you to workstation updates. You
+must have `configured an administrator password <https://tails.net/doc/first_steps/welcome_screen/administration_password/>`_
+on the Tails welcome screen in order to use the graphical updater.
+
+Perform the update to 2.13.10 by clicking "Update Now":
+
+.. image:: ../images/securedrop-updater.png
+
+Fallback: Perform a manual update
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If the graphical updater fails and you want to perform a manual update instead,
+first delete the graphical updater's temporary flag file, if it exists (the
+``.`` before ``securedrop`` is not a typo): ::
+
+  rm ~/Persistent/.securedrop/securedrop_update.flag
+
+This will prevent the graphical updater from attempting to re-apply the failed
+update and has no bearing on future updates. You can now perform a manual
+update by running the following commands: ::
+
+  cd ~/Persistent/securedrop
+  git fetch --tags
+  gpg --keyserver hkps://keys.openpgp.org --recv-key \
+   "2359 E653 8C06 13E6 5295 5E6C 188E DD3B 7B22 E6A3"
+  git tag -v 2.13.0
+
+The output should include the following two lines: ::
+
+    gpg:                using RSA key 2359E6538C0613E652955E6C188EDD3B7B22E6A3
+    gpg: Good signature from "SecureDrop Release Signing Key <securedrop-release-key-2021@freedom.press>" [unknown]
+
+
+Please verify that each character of the fingerprint above matches what is
+on the screen of your workstation. A warning that the key is not certified
+is normal and expected. If the output includes the lines above, you can check
+out the new release: ::
+
+    git checkout 2.13.0
+
+.. important:: If you do see the warning "refname '2.13.0' is ambiguous" in the
+  output, we recommend that you contact us immediately at securedrop@freedom.press
+  (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
+
+Next, run the following commands: ::
+
+  sudo apt update
+  ./securedrop-admin setup
+
 
 .. note:: The apt persistence feature will prompt to install the package
           automatically from persistent storage on each boot. Click


### PR DESCRIPTION
This adds two things to the manual upgrade instructions for the most recent upgrade guide to 2.13.0: 

- Advising the user to select "Install Every Time" when prompted by the apt persistence feature
- Instructing the user to reboot to complete the installation

These instructions are part of the documentation for normal installation process, but are missing/implied on this manual upgrade guide. Adding them here makes the fallback manual upgrade instructions more complete. 