### PR TITLE
Update note in Journalist SVS guide to reflect Tails 7.4 improvements

### DIFF
--- a/docs/journalist/svs.rst
+++ b/docs/journalist/svs.rst
@@ -105,19 +105,28 @@ All key actions are initiated by double-clicking:
 
 - Double-clicking archives in ZIP or gzip format will invoke the **File Roller**
   application to extract the contents to the same location.
+  
+- Double-clicking decrypted messages or documents will attempt to open them in a
+  default application suitable for the file type.
 
 - On Tails 4, double-clicking files that end in ``.gpg`` will attempt to decrypt
   the contents to the same directory. If you have configured a passphrase for your
   *Submission Key*, you will be prompted for it.
 
-- On Tails 5.1 or greater, double-clicking the ``.gpg`` file will launch
+- On Tails 5, double-clicking the ``.gpg`` file will launch
   an application called **Kleopatra**, from which you can decrypt the file and
   save the result to the same directory.
+  
+- On Tails 7.0, 7.1, 7.2, or 7.3, you will need to *first* open **Kleopatra** (**Apps ▸ Accessories ▸ Kleopatra**) before attempting to double-click any ``.gpg`` files.
 
-.. note:: On Tails 7.0 or greater, you will need to *first* open **Kleopatra** (**Apps ▸ Accessories ▸ Kleopatra**) before attempting to double-click any ``.gpg`` files. 
+.. note:: If you are using any of these versions, please contact your *Administrator* about upgrading to Tails 7.4 or later.
 
-- Double-clicking decrypted messages or documents will attempt to open them in a
-  default application suitable for the file type.
+- On all other versions of Tails, double-clicking the ``.gpg`` file will decrypt the
+  file and attempt to open them in a default application suitable for the file type.
+
+
+
+
 
 If the default application does not work, you can right-click on the
 document and choose **Open with Other Application...** to try opening


### PR DESCRIPTION
This small PR updates the note to Journalists using the Secure Viewing Station, noting that Tails versions between 7.0 and 7.3 require first opening Kleopatra before trying to double-click .gpg files. It also suggests that they contact their Admins about upgrading to 7.4 or later (probably no need for them to hang around on those buggier versions re: decryption behavior).

@ChumOfChance I know you mentioned a list of "if you are on Tails x.xx", but I had trouble actually finding it in the docs. If I overlooked it and you think we should add something there, please point me in that direction and I'll tack on an extra commit.

## Checklist
- [ ] Visual review

This change accounts for:
- [x] local preview of changes beyond typo-level edits