### PR TITLE
Remove HTTP links and check for new ones as part of the linting process

### DIFF
--- a/check_errors.sh
+++ b/check_errors.sh
@@ -10,5 +10,19 @@ if grep -R --exclude-dir='_build' ansible_base docs/; then
   exit 1
 fi
 
+# Check for any HTTP links, except for those that are part of an onion address
+# or those that are part of the SVG XML spec
+if grep -R -I -n -P \
+   'http://(?![^[:space:]]*(\.onion|xml))' \
+   --exclude-dir='_build' \
+   --exclude-dir='docs/diagrams' \
+   --exclude='*.svg' \
+   --exclude='conf.py' \
+   --exclude='rebuild_admin.rst' \
+   docs/; then
+  echo "HTTP links found"
+  exit 1
+fi
+
 echo "No common errors found."
 exit 0

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/_static/rtd_dark.css
+++ b/docs/_static/rtd_dark.css
@@ -1,6 +1,6 @@
 /*!
  * @name          Readthedocs
- * @namespace     http://userstyles.org
+ * @namespace     https://userstyles.org
  * @description	  Styles the documentation pages hosted on Readthedocs.io
  * @author        Anthony Post
  * @homepage      https://userstyles.org/styles/142968

--- a/docs/admin/deployment/https_source_interface.rst
+++ b/docs/admin/deployment/https_source_interface.rst
@@ -164,8 +164,8 @@ rerun the configuration scripts: ::
 
 The webserver configuration will be updated to apply the HTTPS settings.
 Confirm that you can access the Source Interface at
-``https://<onion_url>``, and also that the HTTP URL
-``http://<onion_url>`` redirects automatically to HTTPS.
+``https://<onion_address>.onion``, and also that the HTTP URL
+``http://<onion_address>.onion`` redirects automatically to HTTPS.
 
 .. note:: By default, Tor Browser will send an OCSP request to a Certificate
     Authority (CA) to check if the Source Interface certificate has been revoked.

--- a/docs/admin/maintenance/ossec_alerts.rst
+++ b/docs/admin/maintenance/ossec_alerts.rst
@@ -78,7 +78,7 @@ In some cases, authentication or transport encryption mechanisms will
 vary and you may require later edits to the Postfix configuration
 (mainly /etc/postfix/main.cf) on the *Monitor Server* in order to get
 alerts to work. You can consult `Postfix's official
-documentation <http://www.postfix.org/documentation.html>`__ for help,
+documentation <https://www.postfix.org/documentation.html>`__ for help,
 although we've described some common scenarios in the
 :ref:`troubleshooting section <troubleshooting_ossec>`.
 

--- a/docs/admin/reference/responsibilities.rst
+++ b/docs/admin/reference/responsibilities.rst
@@ -60,7 +60,7 @@ portal.
 In rare circumstances when a technical fix is extremely time sensitive, we may
 provide signed patches to impacted SecureDrop instances. Even in these cases, we
 ask that you never install code provided to you that is not signed using the
-current `SecureDrop release key <http://securedrop.org/securedrop-release-key.asc>`__.
+current `SecureDrop release key <https://securedrop.org/securedrop-release-key.asc>`__.
 
 When in doubt how to resolve an issue, please avoid following technical
 instructions that have not been vetted by the SecureDrop team. If you encounter

--- a/docs/admin/reference/ssh_access.rst
+++ b/docs/admin/reference/ssh_access.rst
@@ -55,7 +55,7 @@ the *Application Server* and *Monitor Server*.
   `this resource`_ to cover the fundamentals.
 
 .. _`this resource`:
-  http://linuxcommand.org/lc3_learning_the_shell.php
+  https://linuxcommand.org/lc3_learning_the_shell.php
 
 Shutting Down the Servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/includes/squash-commits.txt
+++ b/docs/includes/squash-commits.txt
@@ -5,7 +5,7 @@
           this by squashing closely related commits through an interactive 
           rebase once your PR is close to being merged. If you are unfamiliar 
           with how to squash commits with rebase, check out this 
-          `blog post <http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html>`__.
+          `blog post <https://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html>`__.
 
           If you would like a project maintainer to help you with squashing 
           commits in a PR, please don't hesitate to leave a comment requesting

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -65,7 +65,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 


### PR DESCRIPTION
This PR removes HTTP links where not required as either part of .onion names, or part of XML specs.

It also adds a check to the linter to make sure any new HTTP links are immediately flagged. 

## Test plan
- [ ] Try modifying the docs to add an http-only link.
- [ ] Ensure that the linter throws an error
- [ ] Change the link to HTTPS and ensure the linter is happy again
- [ ] Visual review
- [ ] CI passes