### PR TITLE
Bump version to 2.15.1 and update upgrade guide

### DIFF
--- a/docs/admin/installation/set_up_admin_tails.rst
+++ b/docs/admin/installation/set_up_admin_tails.rst
@@ -139,7 +139,7 @@ signed with the release signing key:
 
     cd ~/securedrop/
     git fetch --tags
-    git tag -v 2.15.0
+    git tag -v 2.15.1
 
 The output should include the following two lines:
 
@@ -160,9 +160,9 @@ screen of your workstation. If it does, you can check out the new release:
 
 .. code:: sh
 
-    git checkout 2.15.0
+    git checkout 2.15.1
 
-.. important:: If you see the warning ``refname '2.15.0' is ambiguous`` in the
+.. important:: If you see the warning ``refname '2.15.1' is ambiguous`` in the
                output, we recommend that you contact us immediately at
                securedrop@freedom.press (`GPG encrypted <https://securedrop.org/sites/default/files/fpf-email.asc>`__).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ author = u"SecureDrop Team and Contributors"
 # built documents.
 #
 # The short X.Y version.
-version = "2.15.0"
+version = "2.15.1"
 # The full version, including alpha/beta/rc tags.
 # On the live site, this will be overridden to "stable" or "latest".
 release = os.environ.get("SECUREDROP_DOCS_RELEASE", version)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -152,7 +152,7 @@ Get Started
    :maxdepth: 2
    :hidden:
 
-   upgrade/2.14.0_to_2.15.0.rst
+   upgrade/2.14.0_to_2.15.1.rst
    upgrade/2.13.0_to_2.14.0.rst
    upgrade/2.12.10_to_2.13.0.rst
    upgrade/2.12.9_to_2.12.10.rst

--- a/docs/upgrade/2.14.0_to_2.15.1.rst
+++ b/docs/upgrade/2.14.0_to_2.15.1.rst
@@ -1,16 +1,21 @@
 .. _latest_upgrade_guide:
 
-Upgrade from 2.14.10 to 2.15.0
+Upgrade from 2.14.10 to 2.15.1
 ==============================
 
-Changes in SecureDrop 2.15.0
+Changes in SecureDrop 2.15.1
 ----------------------------
 
 SecureDrop version 2.15.0 enables the v2 Journalist API to support the `upcoming SecureDrop Inbox <https://securedrop.org/news/securedrop-inbox-is-coming/>`_.
 
-For more details, see the `announcement for this release <https://securedrop.org/news/securedrop-2_15_0-released/>`_.
+SecureDrop 2.15.1 was released a few days later to improve the memory management used by the SecureDrop application
+when responding to v2 Journalist API requests, and fix an issue where restoring
+backups without transferring over the network would previously fail.
 
-Update Workstations to SecureDrop 2.15.0
+For more details, see the `announcement for the 2.15.0 release <https://securedrop.org/news/securedrop-2_15_0-released/>`_,
+as well as the `announcement for 2.15.1 <https://securedrop.org/news/securedrop-2_15_1-released/>`_.
+
+Update Workstations to SecureDrop 2.15.1
 ----------------------------------------
 
 .. important:: We recommend backing up your workstations prior to
@@ -40,7 +45,7 @@ You can verify the installed version number by running: ::
 
     sudo apt policy securedrop-admin
 
-and confirming that you see version '2.15.0' is installed.
+and confirming that you see version '2.15.1' is installed.
 
 Getting Support
 ---------------


### PR DESCRIPTION
This bumps the version numbers and modifies the existing 2.15.0 upgrade guide to reflect the 2.15.1 release.

## Test plan
- [ ] Visual review
- [ ] CI is happy

## Checklist

This change accounts for:
- [ ] local preview of changes beyond typo-level edits