### PR TITLE
docs: fix typo in upgrade guide from v2.14.0

### DIFF
--- a/docs/upgrade/2.14.0_to_2.15.1.rst
+++ b/docs/upgrade/2.14.0_to_2.15.1.rst
@@ -1,7 +1,7 @@
 .. _latest_upgrade_guide:
 
-Upgrade from 2.14.10 to 2.15.1
-==============================
+Upgrade from 2.14.0 to 2.15.1
+=============================
 
 Changes in SecureDrop 2.15.1
 ----------------------------


### PR DESCRIPTION
Fixes a tiny typo in the new version numbers introduced in #800.