### PR TITLE
Fix install list of journalist alert creds

### DIFF
--- a/docs/admin/installation/install.rst
+++ b/docs/admin/installation/install.rst
@@ -101,6 +101,7 @@ continuing:
 -  the username of the system admin
 
 If configuring Daily Journalist Alert emails (this is optional and can be configured later), you will also need:
+
 -  the Journalist Alert Public Key
 -  the Journalist Alert Public Key  fingerprint
 -  the email address that will receive the Daily Journalist Alerts


### PR DESCRIPTION
This fixes a tiny formatting typo that cause a list not to be rendered properly. 