### PR TITLE
Update Export Device secure erasure instructions and recommendations

### DIFF
--- a/docs/admin/installation/provisioning_usb.rst
+++ b/docs/admin/installation/provisioning_usb.rst
@@ -88,3 +88,12 @@ Creating a VeraCrypt-encrypted drive
   its decryption password to the Journalists who will be using it. Make sure that
   they store it and its password securely, as it will contain decrypted
   submissions.
+
+Securely erase Export Devices
+-----------------------------
+
+Even if a Journalist regularly deletes files from an Export Device, there remains the possibility that those files will be recoverable by anyone with the decryption password. Because of the underlying technology, simply overwriting data or other "file shredding" techniques are insufficient to securely delete files from USB flash drives.
+
+To protect against the possibility that a compromised Export Device decryption password will give someone access to traces or the full contents of previously exported files, you should securely erase your Export Devices on a regular basis. This is done by re-formatting and re-encrypting the USB flash drive with a new encryption password, following the steps above for a LUKS or VeraCrypt drive as appropriate. You may then reissue the Export Devices to Journalists and provide them with the new decryption password.
+
+You may also choose to destroy the drives by physical means, such as using a hammer or purpose-built shredder to pulverize the drive.

--- a/docs/admin/installation/provisioning_usb.rst
+++ b/docs/admin/installation/provisioning_usb.rst
@@ -92,8 +92,8 @@ Creating a VeraCrypt-encrypted drive
 Securely erase Export Devices
 -----------------------------
 
-Even if a Journalist regularly deletes files from an Export Device, there remains the possibility that those files will be recoverable by anyone with the decryption password. Because of the underlying technology, simply overwriting data or other "file shredding" techniques are insufficient to securely delete files from USB flash drives.
+Due to the underlying technology of USB flash drives, Export Devices are likely to retain recoverable portions of files that have been stored on them even if those files have been delete. 
 
-To protect against the possibility that a compromised Export Device decryption password will give someone access to traces or the full contents of previously exported files, you should securely erase your Export Devices on a regular basis. This is done by re-formatting and re-encrypting the USB flash drive with a new encryption password, following the steps above for a LUKS or VeraCrypt drive as appropriate. You may then reissue the Export Devices to Journalists and provide them with the new decryption password.
+To protect against the possibility that a compromised encryption password will yield access to traces of previously exported files, you should securely erase your Export Devices on a regular basis. This can only be done by re-formatting and re-encrypting the USB flash drive with a new encryption password, following the steps above for a LUKS or VeraCrypt drive as appropriate. You may then reissue the Export Devices to Journalists and provide them with the new decryption password.
 
 You may also choose to destroy the drives by physical means, such as using a hammer or purpose-built shredder to pulverize the drive.

--- a/docs/admin/installation/provisioning_usb.rst
+++ b/docs/admin/installation/provisioning_usb.rst
@@ -92,7 +92,7 @@ Creating a VeraCrypt-encrypted drive
 Securely erase Export Devices
 -----------------------------
 
-Due to the underlying technology of USB flash drives, Export Devices are likely to retain recoverable portions of files that have been stored on them even if those files have been delete. 
+Due to the underlying technology of USB flash drives, Export Devices are likely to retain recoverable portions of files that have been stored on them even if those files have been deleted. 
 
 To protect against the possibility that a compromised encryption password will yield access to traces of previously exported files, you should securely erase your Export Devices on a regular basis. This can only be done by re-formatting and re-encrypting the USB flash drive with a new encryption password, following the steps above for a LUKS or VeraCrypt drive as appropriate. You may then reissue the Export Devices to Journalists and provide them with the new decryption password.
 

--- a/docs/admin/maintenance/decommission.rst
+++ b/docs/admin/maintenance/decommission.rst
@@ -104,7 +104,7 @@ SecureDrop instance.
    Be sure to inform your network administrator of any changes to devices on
    your network.
 #. **Wipe and destroy the USB flash drives.**
-   The USB flash drives used for SecureDrop are all encrypted, either with LUKS or Veracrypt. To securely wipe this kind of storage media, it is necessary to simply re-format *and re-encrypt* the drive, following the :doc:`same steps used in their initial creation</admin/installation/provisioning_usb>`. This will destroy the encryption headers, making any data on the drives unrecoverable. 
+   The USB flash drives used for SecureDrop are all encrypted, either with LUKS or Veracrypt. To securely wipe this kind of storage media, it is necessary to re-format *and re-encrypt* the drive, following the :doc:`same steps used in their initial creation</admin/installation/provisioning_usb>`. This will destroy the encryption headers, making any data on the drives unrecoverable. 
 
    You may also choose to destroy the drives by physical means, such as using a
    hammer or purpose-built shredder to pulverize the drive.

--- a/docs/admin/maintenance/decommission.rst
+++ b/docs/admin/maintenance/decommission.rst
@@ -104,23 +104,10 @@ SecureDrop instance.
    Be sure to inform your network administrator of any changes to devices on
    your network.
 #. **Wipe and destroy the USB flash drives.**
-   Because the USB flash drives used for SecureDrop are all LUKS-encrypted,
-   reformatting the USB flash drives (in particular, overwriting a portion of internal
-   storage called the **LUKS header**) should be sufficient to make any existing
-   data on those drives unrecoverable.
-
-   For example, you could use Tails to launch Gnome Disks,
-   insert and identify the USB flash drive you are trying to erase, and reformat this
-   drive with a new, LUKS-encrypted partition, erasing the existing partition
-   data.
-
-   .. caution:: Be **very** sure you are reformatting the right drive.
-      You may want to use the Secure Viewing Station laptop for this procedure
-      to reduce the risk of accidentally erasing a drive on your regular-use
-      machine.
+   The USB flash drives used for SecureDrop are all encrypted, either with LUKS or Veracrypt. To securely wipe this kind of storage media, it is necessary to simply re-format *and re-encrypt* the drive, following the :doc:`same steps used in their initial creation</admin/installation/provisioning_usb>`. This will destroy the encryption headers, making any data on the drives unrecoverable. 
 
    You may also choose to destroy the drives by physical means, such as using a
-   hammer or purpose-built shredder to pulverize or destroy the drive.
+   hammer or purpose-built shredder to pulverize the drive.
 #. **Wipe and destroy the storage drives on the servers.**
    SecureDrop submissions are stored GPG-encrypted on the Application Server.
    Unless your SecureDrop Submission Key is compromised (or a significant

--- a/docs/journalist/submissions.rst
+++ b/docs/journalist/submissions.rst
@@ -151,9 +151,11 @@ audio, and begin publishing important, high-impact work!
 Securely erase an Export Device
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Even you regularly deletes files from your Export Device, there remains the possibility that those files will be recoverable by anyone with the decryption password. Because of the underlying technology, simply overwriting data or other "file shredding" techniques are insufficient to securely delete files from USB flash drives.
+Due to the underlying technology of USB flash drives, Export Devices are likely to retain recoverable portions of files that have been stored on them even if those files have been delete. 
 
-To protect against the possibility that a compromised Export Device decryption password will give someone access to traces or the full contents of previously exported files, you should securely erase your Export Devices on a regular schedule. You may also wish to do this on a case-by-case basis after handling particularly sensitive files or if you believe a decryption password may be compromised. 
+To protect against the possibility that a compromised encryption password will yield access to traces of previously exported files, you should securely erase your Export Devices on a regular basis. You may also wish to do this on a case-by-case basis after handling particularly sensitive files or if you believe a decryption password may be compromised. 
+
+Securely erasing an Export Device can only be done by re-formatting and re-encrypting the USB flash drive with a new encryption password. You can follow the :doc:`same steps</admin/installation/provisioning_usb>` used to initially create the Export Device, or contact your Administrator.
 
 You may also choose to destroy the drives by physical means, such as using a hammer or purpose-built shredder to pulverize the drive.
 

--- a/docs/journalist/submissions.rst
+++ b/docs/journalist/submissions.rst
@@ -151,7 +151,7 @@ audio, and begin publishing important, high-impact work!
 Securely erase an Export Device
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Due to the underlying technology of USB flash drives, Export Devices are likely to retain recoverable portions of files that have been stored on them even if those files have been delete. 
+Due to the underlying technology of USB flash drives, Export Devices are likely to retain recoverable portions of files that have been stored on them even if those files have been deleted. 
 
 To protect against the possibility that a compromised encryption password will yield access to traces of previously exported files, you should securely erase your Export Devices on a regular basis. You may also wish to do this on a case-by-case basis after handling particularly sensitive files or if you believe a decryption password may be compromised. 
 

--- a/docs/journalist/submissions.rst
+++ b/docs/journalist/submissions.rst
@@ -139,9 +139,6 @@ To access the Export Device on your everyday workstation, follow these steps:
 7. Open the Export Device in your operating system's file manager, and copy
    the contents of interest to your everyday workstation.
 
-As a security precaution, we recommend deleting the files on the Export
-Device after each copy operation.
-
 When you are done, switch back to the VeraCrypt window, and click **Dismount**.
 
 You are now ready to write articles and blog posts, edit video and
@@ -151,6 +148,14 @@ audio, and begin publishing important, high-impact work!
          </admin/deployment/getting_the_most_out_of_securedrop>` to read
          about encouraging sources to use SecureDrop.
 
+Securely erase an Export Device
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Even you regularly deletes files from your Export Device, there remains the possibility that those files will be recoverable by anyone with the decryption password. Because of the underlying technology, simply overwriting data or other "file shredding" techniques are insufficient to securely delete files from USB flash drives.
+
+To protect against the possibility that a compromised Export Device decryption password will give someone access to traces or the full contents of previously exported files, you should securely erase your Export Devices on a regular schedule. You may also wish to do this on a case-by-case basis after handling particularly sensitive files or if you believe a decryption password may be compromised. 
+
+You may also choose to destroy the drives by physical means, such as using a hammer or purpose-built shredder to pulverize the drive.
 
 Safely working with submissions outside the SecureDrop Workstation
 --------------------------------------------------------------------


### PR DESCRIPTION
Fixes #563

Based on the discussion in #563, this PR updates the recommendation for how to securely erase Export Devices.

- Update the instructions for decommissioning SecureDrop to reflect that VeraCrypt is used as well, remove references to the SVS and Tails, and direct readers to the instruction page for creating Export Devices. 
- Add a note on securely erasing Export Devices with a recommendation to do so regularly to the provisioning Export Devices page. 
- Add a similar note on securely erasing Export Devices with a recommendation to do so regularly the Journalist documentation page for working with submissions/exporting submissions. Journalists should also know how and why to securely delete files from Export Devices.

Note that future work is required on the instruction page for creating Export Devices (see https://github.com/freedomofpress/securedrop-docs/issues/817)

## Checklist

This change accounts for:
- [ ] local preview of changes beyond typo-level edits