### PR TITLE
Generalize USB creation instructions

### DIFF
--- a/docs/admin/installation/prepare_installation_media.rst
+++ b/docs/admin/installation/prepare_installation_media.rst
@@ -1,0 +1,137 @@
+.. _prepare_installation_media:
+
+Prepare installation media
+==========================
+
+SecureDrop Application and Monitor Servers run **Ubuntu Server 24.04.3 LTS (Noble Numbat)**. 
+
+SecureDrop Workstation laptops run **Qubes 4.3**.
+
+Preparing your everyday computer
+--------------------------------
+
+Before you can install and configure SecureDrop, you must first download and verify the operating system installation media using a normal, everyday computer. This computer can be running macOS, Windows, or Linux.
+
+In order to verify the integrity of the downloaded installation media, you will need to run commands from a terminal or command line. You’ll also need GnuPG (``gpg``) installed. Consult the list below to learn how to prepare your everyday computer:
+
+* **Linux:** ``gpg`` can be accessed via your favorite Terminal emulator, such as GNOME Console, Konsole, or Ptyxis. If ``gpg`` is not already installed, you can install it from your distribution's package manager tool.
+* **Mac:** ``gpg`` must be manually installed from the `GPG Suite <https://gpgtools.org/>`__. Use Terminal.app, or your favorite third-party terminal emulator, to enter commands.
+* **Windows:** ``gpg`` must be installed via `Gpg4win <https://gpg4win.org/download.html>`__. Use the Windows command line (``cmd.exe``) to enter commands.
+
+Preparing the installation media
+--------------------------------
+
+This guide assumes the use of a USB 3.0 flash drive, although you may also use optical media via an external disc drive (which may make more sense depending on your `security concerns <https://www.qubes-os.org/doc/install-security/>`_).
+
+.. note:: A USB flash drive with a Type-A connector is recommended, as USB-C ports may be disabled on your computer when the BIOS settings are disabled later in the installation
+
+Downloading operating system installers
+----------------------------------------
+
+.. _download_ubuntu:
+
+Download and verify Ubuntu Server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The installation media and the files required to verify it are available on the `Ubuntu Releases page`_. You will need to download the following files:
+
+* `ubuntu-24.04.3-live-server-amd64.iso`_
+* `SHA256SUMS`_
+* `SHA256SUMS.gpg`_
+
+Alternatively, you can use the command line:
+
+.. code:: sh
+
+   cd ~/Downloads
+   curl -OOO https://releases.ubuntu.com/24.04.3/{ubuntu-24.04.3-live-server-amd64.iso,SHA256SUMS{,.gpg}}
+
+.. _Ubuntu Releases page: https://releases.ubuntu.com/
+.. _ubuntu-24.04.3-live-server-amd64.iso: https://releases.ubuntu.com/24.04/ubuntu-24.04.3-live-server-amd64.iso
+.. _SHA256SUMS: https://releases.ubuntu.com/24.04/SHA256SUMS
+.. _SHA256SUMS.gpg: https://releases.ubuntu.com/24.04/SHA256SUMS.gpg
+
+You should verify the Ubuntu image you downloaded hasn't been modified by a malicious attacker or otherwise corrupted. To do so, check its integrity with cryptographic signatures and hashes.
+
+First, download both *Ubuntu Image Signing Keys* and verify their fingerprints. ::
+
+    gpg --recv-key --keyserver hkps://keyserver.ubuntu.com \
+    "C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451" \
+    "8439 38DF 228D 22F7 B374 2BC0 D94A A3F0 EFE2 1092"
+
+.. note:: It is important you type this out correctly. If you are not copy-pasting this command, double-check you have entered it correctly before pressing enter.
+
+Again, when passing the full public key fingerprint to the ``--recv-key`` command, GPG will implicitly verify that the fingerprint of the key received matches the argument passed.
+
+.. caution:: If GPG warns you that the fingerprint of the key received does not match the one requested **do not** proceed with the installation. If this happens, please email us at securedrop@freedom.press.
+
+Next, verify the ``SHA256SUMS`` file. ::
+
+    gpg --keyid-format long --verify SHA256SUMS.gpg SHA256SUMS
+
+Move on to the next step if you see "Good Signature" in the output, as below. Note that any other message (such as "Can't check signature: no public key") means that you are not ready to proceed. ::
+
+    gpg: Signature made Thu 11 Feb 2021 02:07:58 PM EST
+    gpg:                using RSA key 843938DF228D22F7B3742BC0D94AA3F0EFE21092
+    gpg: Good signature from "Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>" [unknown]
+    gpg: WARNING: This key is not certified with a trusted signature!
+    gpg:          There is no indication that the signature belongs to the owner.
+    Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092
+
+The next and final step is to verify the Ubuntu image. ::
+
+    sha256sum -c <(grep ubuntu-24.04.3-live-server-amd64.iso SHA256SUMS)
+
+If the final verification step is successful, you should see the following output in your terminal. ::
+
+    ubuntu-24.04.3-live-server-amd64.iso: OK
+    
+If it does not report a good signature, try deleting the ISO and downloading it again.
+
+.. caution:: If you do not see the line above it is not safe to proceed with the installation. If this happens, please contact us at securedrop@freedom.press.
+             
+Download and verify Qubes OS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Download the ``.iso`` and the ``Detached PGP signature`` for ``Qubes OS 4.3.1`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-os-4-3-1>`_. The ISO is 8 GB approximately, and may take some time to download based on the speed of your Internet connection.
+
+Follow the linked instructions to `verify the ISO <https://doc.qubes-os.org/en/latest/project-security/verifying-signatures.html#how-to-verify-detached-pgp-signatures-on-qubes-isos>`_. Ensure that the ISO and hash values are in the same directory, then run:
+
+.. code-block:: sh
+
+  gpg --keyserver-options no-self-sigs-only,no-import-clean --fetch-keys https://keys.qubes-os.org/keys/qubes-release-4.3-signing-key.asc
+  gpg -v --verify Qubes-R4.3.1-x86_64.iso.asc
+
+The output should look like this:
+
+.. code-block:: sh
+
+  gpg: requesting key from 'https://keys.qubes-os.org/keys/qubes-release-4.3-signing-key.asc'
+  gpg: key 1C3D9B627F3FADA4: 1 signature not checked due to a missing key
+  gpg: /home/user/.gnupg/trustdb.gpg: trustdb created
+  gpg: key 1C3D9B627F3FADA4: public key "Qubes OS Release 4.3 Signing Key" imported
+  gpg: Total number processed: 1
+  gpg:               imported: 1
+  gpg: no ultimately trusted keys found
+
+  gpg: enabled compatibility flags:
+  gpg: assuming signed data in 'Qubes-R4.3.1-x86_64.iso'
+  gpg: Signature made Wed Dec 17 23:33:45 2025 GMT
+  gpg:                using RSA key F3FA3F99D6281F7B3A3E5E871C3D9B627F3FADA4
+  gpg: using pgp trust model
+  gpg: Good signature from "Qubes OS Release 4.3 Signing Key" [unknown]
+  gpg: WARNING: This key is not certified with a trusted signature!
+  gpg:          There is no indication that the signature belongs to the owner.
+  Primary key fingerprint: F3FA 3F99 D628 1F7B 3A3E  5E87 1C3D 9B62 7F3F ADA4
+  gpg: binary signature, digest algorithm SHA512, key algorithm rsa4096
+
+Specifically, you will want to make sure that you see "Good signature" listed in the text. If it does not report a good signature, try deleting the ISO and downloading it again.
+
+.. caution:: If you do not see the line above it is not safe to proceed with the installation. If this happens, please contact us at securedrop@freedom.press.
+
+Create the installation media
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`Follow the steps in this guide to create bootable USB drives <https://ubuntu.com/desktop/docs/en/latest/how-to/create-a-bootable-usb-stick/>`__
+
+.. note:: The guide above is written for Ubuntu, but the same steps and procedures can be used for the Qubes installation image as well.

--- a/docs/admin/installation/prepare_installation_media.rst
+++ b/docs/admin/installation/prepare_installation_media.rst
@@ -88,7 +88,7 @@ If the final verification step is successful, you should see the following outpu
     
 If it does not report a good signature, try deleting the ISO and downloading it again.
 
-.. caution:: If you do not see the line above it is not safe to proceed with the installation. If this happens, please contact us at securedrop@freedom.press.
+.. caution:: If you do not see "Good signature" above it is not safe to proceed with the installation. If this happens, please contact us at securedrop@freedom.press.
              
 Download and verify Qubes OS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin/installation/prepare_installation_media.rst
+++ b/docs/admin/installation/prepare_installation_media.rst
@@ -16,7 +16,7 @@ In order to verify the integrity of the downloaded installation media, you will 
 
 * **Linux:** ``gpg`` can be accessed via your favorite Terminal emulator, such as GNOME Console, Konsole, or Ptyxis. If ``gpg`` is not already installed, you can install it from your distribution's package manager tool.
 * **Mac:** ``gpg`` must be manually installed from the `GPG Suite <https://gpgtools.org/>`__. Use Terminal.app, or your favorite third-party terminal emulator, to enter commands.
-* **Windows:** ``gpg`` must be installed via `Gpg4win <https://gpg4win.org/download.html>`__. Use the Windows command line (``cmd.exe``) to enter commands.
+* **Windows:** ``gpg`` must be installed via `Gpg4win <https://gpg4win.org/download.html>`__. Use the Windows PowerShell to enter commands, which you can find by searching and selecting "Windows PowerShell" from the Start menu.
 
 Preparing the installation media
 --------------------------------
@@ -39,7 +39,7 @@ The installation media and the files required to verify it are available on the 
 * `SHA256SUMS`_
 * `SHA256SUMS.gpg`_
 
-Alternatively, you can use the command line:
+Alternatively, you can use the command line on Linux or Mac:
 
 .. code:: sh
 
@@ -50,6 +50,15 @@ Alternatively, you can use the command line:
 .. _ubuntu-24.04.3-live-server-amd64.iso: https://releases.ubuntu.com/24.04/ubuntu-24.04.3-live-server-amd64.iso
 .. _SHA256SUMS: https://releases.ubuntu.com/24.04/SHA256SUMS
 .. _SHA256SUMS.gpg: https://releases.ubuntu.com/24.04/SHA256SUMS.gpg
+
+or from a Windows PowerShell:
+
+.. code:: sh
+
+   cd ~\Downloads
+   curl.exe -O https://releases.ubuntu.com/24.04.3/ubuntu-24.04.3-live-server-amd64.iso
+   curl.exe -O https://releases.ubuntu.com/24.04.3/SHA256SUMS
+   curl.exe -O https://releases.ubuntu.com/24.04.3/SHA256SUMS.gpg
 
 You should verify the Ubuntu image you downloaded hasn't been modified by a malicious attacker or otherwise corrupted. To do so, check its integrity with cryptographic signatures and hashes.
 

--- a/docs/admin/installation/prepare_sdw.rst
+++ b/docs/admin/installation/prepare_sdw.rst
@@ -18,14 +18,7 @@ Prerequisites
 In order to install SecureDrop Workstation and configure it to use an existing SecureDrop instance, you will need the following:
 
 - A Qubes-compatible laptop based on the :ref:`hardware<hardware_guide>` recommendations. 
-- Qubes installation medium - this guide assumes the use of a USB 3.0 flash drive. Qubes may also be installed via optical media, which may make more sense depending on your `security concerns <https://www.qubes-os.org/doc/install-security/>`_.
-
-  .. note:: A USB flash drive with a Type-A connector is recommended, as USB-C ports may be disabled on your computer when the BIOS settings detailed below are applied.
-
-- A working computer (Linux is recommended and assumed in this guide) to use for verification and creation of the Qubes installation medium.
-
-  .. note:: Tails can be used to perform the tasks below, but due to the size of the Qubes installation ISO, it may make sense to download it on another computer rather than via Tor, and then to use a USB flash drive to transfer it to Tails for verification and creation of the installation medium.
-
+- :ref:`Qubes installation media <prepare_installation_media>`
 - A password manager or other system to generate and store strong passphrases for Qubes full disk encryption (FDE) and user accounts.
 
 A basic knowledge of the Qubes OS is helpful.
@@ -82,54 +75,7 @@ For instructions on how to enable or disable the SecureBoot feature for your
 device, please consult the manufacturer's manual for BIOS settings, as they
 differ for each make and model.
 
-Download and verify Qubes OS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-On the working computer, download the Qubes OS ISO and cryptographic hash values for version ``4.2.4`` from `https://www.qubes-os.org/downloads/ <https://www.qubes-os.org/downloads/#qubes-os-4-2-4>`_. The ISO is 6.8 GB approximately, and may take some time to download based on the speed of your Internet connection.
-
-Follow the linked instructions to `verify the ISO <https://www.qubes-os.org/security/verifying-signatures/#how-to-verify-detached-pgp-signatures-on-qubes-isos>`_. Ensure that the ISO and hash values are in the same directory, then run:
-
-.. code-block:: sh
-
-  gpg --keyserver-options no-self-sigs-only,no-import-clean --fetch-keys https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc
-  gpg -v --verify Qubes-R4.2.4-x86_64.iso.DIGESTS
-  sha256sum -c Qubes-R4.2.4-x86_64.iso.DIGESTS
-
-The output should look like this:
-
-.. code-block:: sh
-
-  gpg: requesting key from 'https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc'
-  gpg: key E022E58F8E34D89F: public key "Qubes OS Release 4.2 Signing Key" imported
-  gpg: Total number processed: 1
-  gpg:               imported: 1
-  gpg: no ultimately trusted keys found
-
-  gpg: armor header: Hash: SHA256
-  gpg: original file name=''
-  gpg: Signature made Mon 17 Feb 2025 12:00:00 AM EST
-  gpg:                using RSA key 9C884DF3F81064A569A4A9FAE022E58F8E34D89F
-  gpg: using pgp trust model
-  gpg: Good signature from "Qubes OS Release 4.2 Signing Key" [unknown]
-  gpg: WARNING: This key is not certified with a trusted signature!
-  gpg:          There is no indication that the signature belongs to the owner.
-  Primary key fingerprint: 9C88 4DF3 F810 64A5 69A4  A9FA E022 E58F 8E34 D89F
-  gpg: textmode signature, digest algorithm SHA256, key algorithm rsa4096
-  Qubes-R4.2.4-x86_64.iso: OK
-  sha256sum: WARNING: 20 lines are improperly formatted
-
-Specifically, you will want to make sure that you see "Good signature" listed in the text. If it does not report a good signature, try deleting the ISO and downloading it again.
-
-Once you've verified the ISO, copy it to your installation medium - for example, if using Linux and a USB flash drive, using the command:
-
-.. code-block:: sh
-
-  sudo dd if=Qubes-R4.2.4-x86_64.iso of=/dev/sdX bs=1048576 && sync
-
-where ``if`` is set to the path to your downloaded ISO file and ``of`` is set to
-the block device corresponding to your USB flash drive. Note that any data on the USB flash drive will be overwritten.
-
-.. caution:: Make sure to verify that you have the correct device name using, for example, the ``lsblk`` command. You should write to the full device (eg. ``/dev/sdc``) rather than to a partition (eg. ``/dev/sdc1``).
 
 Install Qubes OS (estimated wait time: 30-45 minutes)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/admin/installation/prepare_servers.rst
+++ b/docs/admin/installation/prepare_servers.rst
@@ -38,8 +38,6 @@ enumerate recommended BIOS settings for hardware that we have tested.
 Install Ubuntu
 ---------------
 
-The SecureDrop Application Server and Monitor Server run **Ubuntu 24.04.3 LTS (Noble Numbat)**. To install Ubuntu on the servers, you must first download and verify the Ubuntu installation media.
-
 Ubuntu introduction
 ~~~~~~~~~~~~~~~~~~~
 
@@ -47,106 +45,7 @@ Ubuntu introduction
   with, but it is **strongly** encouraged that you read and follow this documentation
   exactly as there are some "gotchas" that may cause your SecureDrop setup to break.
 
-The SecureDrop Application Server and Monitor Server run **Ubuntu Server
-24.04.3 LTS (Noble Numbat)**. To install Ubuntu on the servers, you must first
-download and verify the Ubuntu installation media.
-
-.. _download_ubuntu:
-
-Download the Ubuntu installation media
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The installation media and the files required to verify it are available on the
-`Ubuntu Releases page`_. You will need to download the following files:
-
-* `ubuntu-24.04.3-live-server-amd64.iso`_
-* `SHA256SUMS`_
-* `SHA256SUMS.gpg`_
-
-Alternatively, you can use the command line:
-
-.. code:: sh
-
-   cd ~/Downloads
-   curl -OOO https://releases.ubuntu.com/24.04.3/{ubuntu-24.04.3-live-server-amd64.iso,SHA256SUMS{,.gpg}}
-
-.. _Ubuntu Releases page: https://releases.ubuntu.com/
-.. _ubuntu-24.04.3-live-server-amd64.iso: https://releases.ubuntu.com/24.04/ubuntu-24.04.3-live-server-amd64.iso
-.. _SHA256SUMS: https://releases.ubuntu.com/24.04/SHA256SUMS
-.. _SHA256SUMS.gpg: https://releases.ubuntu.com/24.04/SHA256SUMS.gpg
-
-Verify the Ubuntu installation media
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You should verify the Ubuntu image you downloaded hasn't been modified by
-a malicious attacker or otherwise corrupted. To do so, check its integrity with
-cryptographic signatures and hashes.
-
-First, download both *Ubuntu Image Signing Keys* and verify their
-fingerprints. ::
-
-    gpg --recv-key --keyserver hkps://keyserver.ubuntu.com \
-    "C598 6B4F 1257 FFA8 6632 CBA7 4618 1433 FBB7 5451" \
-    "8439 38DF 228D 22F7 B374 2BC0 D94A A3F0 EFE2 1092"
-
-.. note:: It is important you type this out correctly. If you are not
-          copy-pasting this command, double-check you have
-          entered it correctly before pressing enter.
-
-Again, when passing the full public key fingerprint to the ``--recv-key`` command, GPG
-will implicitly verify that the fingerprint of the key received matches the
-argument passed.
-
-.. caution:: If GPG warns you that the fingerprint of the key received
-             does not match the one requested **do not** proceed with
-             the installation. If this happens, please email us at
-             securedrop@freedom.press.
-
-Next, verify the ``SHA256SUMS`` file. ::
-
-    gpg --keyid-format long --verify SHA256SUMS.gpg SHA256SUMS
-
-Move on to the next step if you see "Good Signature" in the output, as
-below. Note that any other message (such as "Can't check signature: no public
-key") means that you are not ready to proceed. ::
-
-    gpg: Signature made Thu 11 Feb 2021 02:07:58 PM EST
-    gpg:                using RSA key 843938DF228D22F7B3742BC0D94AA3F0EFE21092
-    gpg: Good signature from "Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>" [unknown]
-    gpg: WARNING: This key is not certified with a trusted signature!
-    gpg:          There is no indication that the signature belongs to the owner.
-    Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092
-
-The next and final step is to verify the Ubuntu image. ::
-
-    sha256sum -c <(grep ubuntu-24.04.3-live-server-amd64.iso SHA256SUMS)
-
-If the final verification step is successful, you should see the
-following output in your terminal. ::
-
-    ubuntu-24.04.3-live-server-amd64.iso: OK
-
-.. caution:: If you do not see the line above it is not safe to proceed with the
-             installation. If this happens, please contact us at
-             securedrop@freedom.press.
-
-Create the Ubuntu installation media
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The `Ubuntu website <https://ubuntu.com/>`__ has detailed instructions on how to
-to create a bootable Ubuntu Server USB flash drive.
-
-Follow the instructions at the link below for your operating system, then return
-to this page:
-
-- `Create a bootable Ubuntu USB drive on Mac
-  <https://ubuntu.com/tutorials/create-a-usb-stick-on-macos#1-overview>`__
-- `Create a bootable Ubuntu USB drive on Windows
-  <https://ubuntu.com/tutorials/create-a-usb-stick-on-windows#1-overview>`__
-- `Create a bootable Ubuntu USB drive on Linux
-  <https://ubuntu.com/tutorials/create-a-usb-stick-on-ubuntu#1-overview>`__
-
-With the Ubuntu Server install USB flash drive ready, you may now proceed to the installation.
+The SecureDrop Application Server and Monitor Server run **Ubuntu Server 24.04.3 LTS (Noble Numbat)**. To install Ubuntu on the servers, :ref:`you must first download and verify the Ubuntu installation media. <prepare_installation_media>` 
 
 Perform the installation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -176,6 +176,7 @@ or making `a donation <https://freedom.press/donate>`_.
 
    admin/installation/installation_overview
    admin/installation/hardware
+   admin/installation/prepare_installation_media
    admin/installation/email_alerts
    admin/installation/prepare_sdw
    admin/installation/generate_submission_key


### PR DESCRIPTION
Fixes #756

This PR creates a new page which simplifies and synchronizes the process of downloading, verifying, and flashing both Ubuntu and Qubes. It also links back to this new page from the Workstation and Server install sections, replacing the previous (separate) sections.

I've also added a section to document how Mac and Windows users can run the commands (previously, it was unclear how to do this from our instructions)

## Test plan
 - [ ] Follow the instructions to download and verify both sets of installation media
 - [ ] Follow the linked instructions for flashing both sets of installation media to a flash drive
 - [ ] Visual review
 - [ ] Happy CI