### PR TITLE
Overhaul backup and restore guide, and include instructions for backng up Qubes-based Admin Workstation

### DIFF
--- a/docs/admin/workstation_reference/backup.rst
+++ b/docs/admin/workstation_reference/backup.rst
@@ -1,22 +1,29 @@
 Backup and restore
 ==================
 
-.. TODO possibly need distinct backup and restore instructions for Qubes-based Admin and  Workstations? Possibly not?
-
 Qubes OS has a `backup utility <https://www.qubes-os.org/doc/backup-restore/>`_ that allows for backup and restoration of user-specified qubes and templates.
 
 SecureDrop Workstation requires only that you back up instance-specific secrets and configuration files, although you can optionally back up some additional local data.
 
+.. warning::
+   Backups contain sensitive data, and must be created and stored just as securely as SecureDrop Workstation laptops.
+
 To perform backups, you will need:
 
-- a `LUKS-encrypted <https://workstation.securedrop.org/en/stable/admin/reference/provisioning_usb.html>`_ USB or LUKS-encrypted external hard drive (of sufficient size, if backing up additional local data)
+- a `LUKS-encrypted <https://workstation.securedrop.org/en/stable/admin/reference/provisioning_usb.html>`_ USB flash or external hard drive (of sufficient size, if backing up additional local data)
 - a secure place to store backup credentials (such as a password manager on your primary laptop)
 
 Backup
-------
+------  
+
+Back up a Journalist Workstation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+   Before starting your backup, decide whether you want to back up your data from ``sd-app``. If you skip this step, the first time you log in, all previous messages exchanged between Sources and Journalists, as well as any submitted files, will re-download from your SecureDrop server.
 
 Preserve files from ``dom0`` and ``sd-gpg``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Preserve configuration files and private key material by copying them into ``dom0``.
 
@@ -35,21 +42,16 @@ If you have made customizations to ``dom0`` (for example, custom RPC policy file
   mkdir ~/etc-qubes && cp -r /etc/qubes ~/etc-qubes
   mkdir ~/etc-qubes-rpc && cp -r /etc/qubes-rpc ~/etc-qubes-rpc
 
-Back up a SecureDrop Workstation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. note::
-  Backups contain sensitive data, and must be created and stored just as securely as SecureDrop Workstation itself.
-
-  If performing this backup as part of a migration (from one machine to another or from one version of Qubes OS to another), we suggest you retain the backup only during the migration process, and destroy it after the migration is complete. The easiest way to do this is to create a LUKS-encrypted drive, follow this guide to create your backup, and then wipe (reformat) or destroy the drive after you have successfully restored it onto the new machine, which should ideally happen the same day. In all cases, follow your organization's internal policies on handling sensitive assets and information.
-
-  If you are looking to back up your own customized components of SecureDrop Workstation for long-term storage, we suggest taking that backup separately from the backup of SecureDrop Workstation components so that you can avoid proliferating copies of sensitive assets.
-
-Before starting your backup, decide whether you want to back up your data from ``sd-app``. If you skip this step, the first time you log in, all previous messages exchanged between Sources and Journalists, as well as any submitted files, will re-download from your SecureDrop server.
+  
+Select qubes to back up
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Ensure your storage medium is plugged in, attached to ``sd-devices``, and unlocked.
 
 Navigate to |qubes_menu| **▸** |qubes_menu_gear| **▸ Qubes Tools ▸ Backup Qubes**, and move all qubes from "Selected" to "Available" by pressing the ``<<`` button.
+
+.. warning::
+   If you are looking to back up your own customized components of SecureDrop Workstation for long-term storage, we suggest taking that backup separately from the backup of SecureDrop Workstation components so that you can avoid proliferating copies of sensitive assets.
 
 To target a qube for backup, highlight it and move it into the "Selected" column by pressing the ``>`` button. Select:
 
@@ -57,21 +59,53 @@ To target a qube for backup, highlight it and move it into the "Selected" column
 - the ``sd-app`` qube (optional), noting the warning above
 - any customized qubes (and their templates) that you may wish to preserve, noting the warning above.
 
+If your Journalist Workstation also functions as an Admin Workstation, make sure to also select:
+
+- the ``sd-admin`` qube
+- the ``sd-vault`` qube
+
 You do not need to back up the other ``sd-`` qubes.
 
-Click "Next", and in "Backup destination," specify the qube and directory corresponding to your storage medium's current mount point.
+Click "Next", and in "Backup destination," specify the ``sd-devices`` qube and directory corresponding to your storage medium's current mount point.
+
+Perform the backup
+^^^^^^^^^^^^^^^^^^
 
 Set a strong, unique backup passphrase (7-word diceware), and ensure this passphrase is stored securely outside SecureDrop Workstation.
 
 .. note::
- This passphrase protects sensitive components of your SecureDrop instance, including the Submission Private Key, and unencrypted submissions (if ``sd-app`` is backed up). Ensure it is a very strong password and is stored securely.
+   This passphrase protects sensitive components of your SecureDrop instance, including the Submission Private Key, and unencrypted submissions (if ``sd-app`` is backed up). Ensure it is a very strong password and is stored securely.
 
 Uncheck "save backup profile," then proceed with the backup.
+
+
+Back up an Admin Workstation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The process for backing up an Admin Workstation is similar to the process for a Journalist Workstation, although here there are fewer sensitive assets that are copied.
+
+To perform a backup of the Admin Workstation:
+
+Back up the ``sd-admin`` qube
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ensure your storage medium is plugged in, attached to ``sd-devices``, and unlocked.
+
+Navigate to |qubes_menu| **▸** |qubes_menu_gear| **▸ Qubes Tools ▸ Backup Qubes**, and move all qubes from "Selected" to "Available" by pressing the ``<<`` button.
+
+Highlight the ``sd-admin`` and ``sd-vault`` qubes, then move them into the "Selected" column by pressing the ``>`` button. You do not need to back up the other ``sd-`` qubes.
+
+Click "Next", and in "Backup destination," specify the ``sd-devices`` qube and directory corresponding to your storage medium's current mount point.
+
+Verify the backup
+~~~~~~~~~~~~~~~~~
 
 Qubes OS recommends verifying the integrity of the backup once the backup completes, and this should be done on the same machine where the backup was created. This can be done by using the Restore Backup GUI tool and selecting "Verify backup integrity, but do not restore the data." For details, see the `Qubes OS backup documentation <https://www.qubes-os.org/doc/backup-restore/>`_.
 
 .. warning::
-  Any files or data not mentioned above and not backed up elsewhere will be destroyed. Ensure that any other data on your system (for example, using KeepassXC in the ``vault`` qube, or data stored in other qubes) have been backed up and the integrity of the backup has been verified before proceeding.
+  Any files or data not mentioned above and not backed up elsewhere are at risk of being lost or destroyed. Ensure that any other data on your system (for example, using KeepassXC in the ``vault`` qube, or data stored in other qubes) have been backed up and the integrity of the backup has been verified.
+ 
+  
 
 Restore
 -------
@@ -91,9 +125,24 @@ Example: If you wish to restore the ``vault`` qube, rename or delete the existin
 Restore backup (SecureDrop Workstation components)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+   If you are migrating from one machine to another or from one version of Qubes OS to another, we suggest you wipe (reformat) or destroy the drive after you have successfully restored it onto the new machine (which should ideally happen the same day). In all cases, follow your organization's internal policies on handling sensitive assets and information.
+
 Plug in your backup medium and unlock it as during the backup. By default on a new system, your peripheral devices will be managed by a qube called ``sys-usb``.
 
-Navigate to |qubes_menu| **▸** |qubes_menu_gear| **▸ Qubes Tools ▸ Restore Backup**, and enter the location of the backup file. You do not need to adjust the default Restore options, unless you have made customizations to the backup. Enter the decryption/verification passphrase, and proceed to restoring the available qubes (which should include ``dom0`` and possibly ``sd-app``).
+Navigate to |qubes_menu| **▸** |qubes_menu_gear| **▸ Qubes Tools ▸ Restore Backup**, and enter the location of the backup file. You do not need to adjust the default Restore options, unless you have made customizations to the backup. Enter the decryption/verification passphrase, and proceed to restoring the available qubes.
+
+If you are restoring a Journalist Workstation, you should ensure you restore:
+
+- ``dom0``
+- (optional) ``sd-app``
+
+If you are restoring an Admin Workstation, you should ensure you restore:
+
+- ``sd-admin``
+- ``sd-vault``
+
+If you are using a combination Journalist and Admin Workstation, restore all items listed above.
 
 We suggest restoring only those qubes, provisioning SecureDrop Workstation, and then restoring any customized qubes you may have had once that process is complete. This way SecureDrop Workstation is provisioned on a clean system and can implement the security measures it requires before any additional qubes are configured.
 
@@ -156,7 +205,7 @@ Reinstall SecureDrop Workstation:
 Restore additional keys to ``sd-gpg``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In a ``dom0`` terminal:
+If you are using a Journalist Workstation and have multiple Submission Keys, perform the following commands from a ``dom0`` terminal:
 
 .. code-block:: sh
 


### PR DESCRIPTION
This PR overhauls the backup and restore guide, focusing on the diverging paths for Journalist and Admin Workstations.

Fixes #769

Also fixes https://github.com/freedomofpress/securedrop-workstation/issues/1561


## Test plan
- [ ] CI passes
- [ ] Visual review
- [ ] If possible (i.e., sd-admin is ready), perform a backup using the updated instructions

## Checklist

This change accounts for:
- [x] local preview of changes beyond typo-level edits